### PR TITLE
Adjust models for new publishing flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 /data/db/virtuoso.trx
 !/data/db/virtuoso.ini
 
+# Delta files
+/data/files
+
 .DS_Store
 *~
 

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -81,7 +81,8 @@ defmodule Acl.UserGroups.Config do
                         "http://data.lblod.info/vocabularies/mobiliteit/MaatregelConcept",
                         "https://data.vlaanderen.be/ns/mobiliteit#Verkeersbordcategorie",
                         "https://data.vlaanderen.be/ns/mobiliteit#Verkeersbordconcept",
-                        "http://data.lblod.info/vocabularies/mobiliteit/VerkeersbordconceptStatusCode"
+                        "http://data.lblod.info/vocabularies/mobiliteit/VerkeersbordconceptStatusCode",
+                        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject"
                       ]
                     } },
                   %GraphSpec{

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -42,6 +42,7 @@ defmodule Acl.UserGroups.Config do
                     graph: "http://mu.semte.ch/graphs/public",
                     constraint: %ResourceConstraint{
                       resource_types: [
+                        "http://data.vlaanderen.be/ns/besluitvorming#Agenda",
                         "http://mu.semte.ch/vocabularies/ext/EditorDocumentStatus",
                         "http://mu.semte.ch/vocabularies/ext/EditorDocumentFolder",
                         "http://mu.semte.ch/vocabularies/ext/Template",
@@ -125,6 +126,7 @@ defmodule Acl.UserGroups.Config do
                     graph: "http://mu.semte.ch/graphs/organizations/",
                     constraint: %ResourceConstraint{
                       resource_types: [
+                        "http://data.vlaanderen.be/ns/besluitvorming#Agenda",
                         "http://mu.semte.ch/vocabularies/ext/EditorDocument",
                         "http://mu.semte.ch/vocabularies/ext/DocumentContainer",
                         "http://mu.semte.ch/vocabularies/ext/VersionedAgenda",
@@ -156,6 +158,7 @@ defmodule Acl.UserGroups.Config do
                     graph: "http://mu.semte.ch/graphs/temporary-sync-",
                     constraint: %ResourceConstraint{
                       resource_types: [
+                        "http://data.vlaanderen.be/ns/besluitvorming#Agenda",
                         "http://data.vlaanderen.be/ns/besluit#Zitting",
                         "http://data.vlaanderen.be/ns/besluit#Stemming",
                         "http://data.vlaanderen.be/ns/besluit#Besluit",
@@ -183,6 +186,7 @@ defmodule Acl.UserGroups.Config do
                     graph: "http://mu.semte.ch/graphs/organizations/",
                     constraint: %ResourceConstraint{
                       resource_types: [
+                        "http://data.vlaanderen.be/ns/besluitvorming#Agenda",
                         "http://mu.semte.ch/vocabularies/ext/EditorDocument",
                         "http://data.vlaanderen.be/ns/besluit#Zitting",
                         "http://mu.semte.ch/vocabularies/ext/Agenda",

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -1,1 +1,23 @@
-export default [];
+export default [
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+      },
+      object: {
+        type: 'uri',
+        value: 'http://mu.semte.ch/vocabularies/ext/signing/PublishedResource'
+      }
+    },
+    callback: {
+      url: 'http://published-resource-producer/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true
+    }
+  },
+];

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -21,6 +21,13 @@ defmodule Dispatcher do
   # match "/themes/*path" do
   #   Proxy.forward conn, path, "http://resource/themes/"
   # end
+  #
+  get "/sync/files/*path" do
+    Proxy.forward conn, path, "http://published-resource-producer/files/"
+  end
+  match "/files/*path" do
+    Proxy.forward conn, path, "http://file/files/"
+  end
 
   match "/blockchain/*path" do
     Proxy.forward conn, path, "http://blockchain/"

--- a/config/resources/repository.lisp
+++ b/config/resources/repository.lisp
@@ -4,6 +4,7 @@
 (add-prefix "tmp" "http://mu.semte.ch/vocabularies/tmp/")
 
 (add-prefix "besluit" "http://data.vlaanderen.be/ns/besluit#")
+(add-prefix "bv" "http://data.vlaanderen.be/ns/besluitvorming#")
 (add-prefix "mandaat" "http://data.vlaanderen.be/ns/mandaat#")
 (add-prefix "persoon" "http://data.vlaanderen.be/ns/persoon#")
 (add-prefix "generiek" "http://data.vlaanderen.be/ns/generiek#")

--- a/config/resources/slave-besluit-domain.lisp
+++ b/config/resources/slave-besluit-domain.lisp
@@ -16,7 +16,12 @@
                          :as "vorige-agendapunt")
              (behandeling-van-agendapunt :via ,(s-prefix "dct:subject")
                                          :inverse t
-                                         :as "behandeling"))
+                                         :as "behandeling")
+             (agenda :via ,(s-prefix "bv:isOnderdeelVan")
+                     :inverse t
+                     :as "agenda"
+                     )
+             )
   :resource-base (s-url "http://data.lblod.info/id/agendapunten/")
   :features '(include-uri)
   :on-path "agendapunten")
@@ -225,8 +230,9 @@
                           :as "agendapunten")
               (uittreksel :via ,(s-prefix "ext:uittreksel")
                           :as "uittreksels")
-              (agenda :via ,(s-prefix "ext:agenda")
-                          :as "agendas"))
+              (agenda :via ,(s-prefix "bv:isAgendaVoor")
+                      :inverse t
+                      :as "publicatie-agendas"))
 
   :has-one `((bestuursorgaan :via ,(s-prefix "besluit:isGehoudenDoor")
                              :as "bestuursorgaan")

--- a/config/resources/slave-besluit-domain.lisp
+++ b/config/resources/slave-besluit-domain.lisp
@@ -17,7 +17,7 @@
              (behandeling-van-agendapunt :via ,(s-prefix "dct:subject")
                                          :inverse t
                                          :as "behandeling")
-             (agenda :via ,(s-prefix "bv:isOnderdeelVan")
+             (agenda :via ,(s-prefix "dct:isPartOf")
                      :inverse t
                      :as "agenda"
                      )

--- a/config/resources/slave-publicatie-gn-domain.lisp
+++ b/config/resources/slave-publicatie-gn-domain.lisp
@@ -5,17 +5,21 @@
   :properties `((:state :string ,(s-prefix "ext:stateString"))
                 (:content :string ,(s-prefix "ext:content"))
                 (:kind :string ,(s-prefix "ext:agendaKind")))
-  :has-many `((signed-resource :via ,(s-prefix "ext:signsAgenda")
+  :has-many `(
+              (signed-resource :via ,(s-prefix "ext:signsAgenda")
                                :inverse t
-                               :as "signed-resources"))
-  :has-one `((published-resource :via ,(s-prefix "ext:publishesAgenda")
+                               :as "signed-resources")
+              )
+  :has-one `(
+             (published-resource :via ,(s-prefix "ext:publishesAgenda")
                                  :inverse t
                                  :as "published-resource")
              (editor-document :via ,(s-prefix "prov:wasDerivedFrom")
                               :as "editor-document")
              (document-container :via ,(s-prefix "ext:hasVersionedAgenda")
                                  :inverse t
-                                 :as "document-container"))
+                                 :as "document-container")
+             )
   :resource-base (s-url "http://data.lblod.info/prepublished-agendas/")
   :features '(include-uri)
   :on-path "versioned-agendas")
@@ -90,8 +94,8 @@
                 (:created-on :datetime ,(s-prefix "dct:created")))
   :has-one `((blockchain-status :via ,(s-prefix "sign:status")
                                 :as "status")
-             (versioned-agenda :via ,(s-prefix "ext:signsAgenda")
-                               :as "versioned-agenda")
+             (agenda :via ,(s-prefix "ext:signsAgenda")
+                               :as "agenda")
              (versioned-besluiten-lijst :via ,(s-prefix "ext:signsBesluitenlijst")
                                         :as "versioned-besluiten-lijst")
              (versioned-notulen :via ,(s-prefix "ext:signsNotulen")
@@ -112,8 +116,8 @@
                 (:submission-status :uri ,(s-prefix "ext:submissionStatus")))
   :has-one `((blockchain-status :via ,(s-prefix "sign:status")
                                 :as "status")
-             (versioned-agenda :via ,(s-prefix "ext:publishesAgenda")
-                               :as "versioned-agenda")
+             (agenda :via ,(s-prefix "ext:publishesAgenda")
+                               :as "agenda")
              (versioned-besluiten-lijst :via ,(s-prefix "ext:publishesBesluitenlijst")
                                         :as "versioned-besluiten-lijst")
              (versioned-behandeling :via ,(s-prefix "ext:publishesBehandeling")
@@ -148,15 +152,28 @@
   :on-path "notulen")
 
 (define-resource agenda ()
-  :class (s-prefix "ext:Agenda")
-  :properties `((:inhoud :string ,(s-prefix "prov:value")))
-  :has-one `((published-resource :via ,(s-prefix "prov:wasDerivedFrom")
-                             :as "publication")
-             (zitting :via ,(s-prefix "ext:agenda")
-                      :inverse t
-                      :as "zitting"))
-  :has-many `((agendapunt :via ,(s-prefix "ext:agendaAgendapunt")
-                                  :as "agendapunten"))
+  :class (s-prefix "bv:Agenda")
+  :properties `(
+                (:inhoud :string ,(s-prefix "prov:value"))
+                (:agenda-status :string ,(s-prefix "bv:agendaStatus"))
+                (:agenda-type :string ,(s-prefix "bv:agendaType"))
+                (:rendered-content :string ,(s-prefix "ext:renderedContent"))
+                )
+  :has-one `(
+             (zitting :via ,(s-prefix "bv:isAgendaVoor")
+                      :as "zitting")
+             (published-resource :via ,(s-prefix "ext:publishesAgenda")
+                                 :inverse t
+                                 :as "published-resource")
+             )
+  :has-many `(
+              (agendapunt :via ,(s-prefix "bv:isOnderdeelVan")
+                          :inverse t
+                          :as "agendapunten")
+              (signed-resource :via ,(s-prefix "ext:signsAgenda")
+                               :inverse t
+                               :as "signed-resources")
+              )
   :resource-base (s-url "http://data.lblod.info/id/agendas/")
   :features '(include-uri)
   :on-path "agendas")

--- a/config/resources/slave-publicatie-gn-domain.lisp
+++ b/config/resources/slave-publicatie-gn-domain.lisp
@@ -167,7 +167,7 @@
                                  :as "published-resource")
              )
   :has-many `(
-              (agendapunt :via ,(s-prefix "bv:isOnderdeelVan")
+              (agendapunt :via ,(s-prefix "dct:isPartOf")
                           :inverse t
                           :as "agendapunten")
               (signed-resource :via ,(s-prefix "ext:signsAgenda")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,7 +141,7 @@ services:
     labels:
       - "logging=true"
   published-resource-producer:
-    image: lblod/published-resource-producer:0.0.1
+    image: lblod/published-resource-producer:0.0.2
     volumes:
       - ./data/files:/share
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,3 +134,9 @@ services:
     logging: *default-logging
     labels:
       - "logging=true"
+  published-resource-producer:
+    image: lblod/published-resource-producer:0.0.1
+    volumes:
+      - ./data/files:/share
+    environment:
+      RELATIVE_FILE_PATH: "deltas/published-resource"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,12 @@ services:
     logging: *default-logging
     labels:
       - "logging=true"
+  file:
+    image: semtech/mu-file-service:3.1.0
+    links:
+      - database:database
+    volumes:
+      - ./data/files/:/share/
   # sync:
   #   image: lblod/gemeente-ocmw-sync-service:0.2.4
   #   links:


### PR DESCRIPTION
Attaches published and signed resources to the Agenda model instead of the VersionedAgenda
Uses a more descriptive name for the prepublished content (renderedContent instead of content to signify it is a bunch of html which can be injected directly into the template)

related prs: 
- [frontend](https://github.com/lblod/frontend-gelinkt-notuleren/pull/19)
- [service](https://github.com/lblod/notulen-prepublish-service/pull/3)