### PR TITLE
added env variable to set the timezone of the prepublisher

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,8 @@ services:
       - "logging=true"
   preimporter:
     image: lblod/notulen-prepublish-service:0.7.1
+    environment: 
+      TZ: "Europe/Brussels"
     restart: always
     logging: *default-logging
     labels:


### PR DESCRIPTION
We have to set the timezone of the prepublisher to be always equal to the Belgium timezone, I decided to set this on the docker container, but open to suggestions