### PR TITLE
Setup release-it and lerna-changelog

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,17 @@
+{
+  "git": {
+    "requireBranch": [
+      "master",
+      "development"
+    ]
+  },
+  "github": {
+    "release": true
+  },
+  "plugins": {
+    "release-it-lerna-changelog": {
+      "infile": "CHANGELOG.md",
+      "launchEditor": true
+    }
+  }
+}

--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,5 @@
+{
+  "changelog": {
+    "repo": "lblod/app-gelinkt-notuleren"
+  }
+}


### PR DESCRIPTION
Thankfully neither actually needs a package.json to work.

However, a small caveat: since the lerna plugin can no longer be marked as a dependency of the project, it has to be provided in another way. There are two sensible options:
- keep using `npx`:
replace the `npx release-it` command with the following:
`npx --package=release-it --package=release-it-lerna-changelog --package=lerna-changelog -c release-it`

- install everything globally