### PR TITLE
bump frontend to v2.15.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
     max-file: "3"
 services:
   editor:
-    image: lblod/frontend-gelinkt-notuleren:2.14.0
+    image: lblod/frontend-gelinkt-notuleren:2.15.0
     links:
       - identifier:backend
     restart: always


### PR DESCRIPTION
https://github.com/lblod/frontend-gelinkt-notuleren/releases/tag/v2.15.0
adds (experimental) support for acmidm switch
bugfix for large file uploads
fixes drag icon