### PR TITLE
bump prepublisher to 1.4.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
     labels:
       - "logging=true"
   preimporter:
-    image: lblod/notulen-prepublish-service:1.4.2
+    image: lblod/notulen-prepublish-service:1.4.3
     environment: 
       TZ: "Europe/Brussels"
     restart: always


### PR DESCRIPTION
https://github.com/lblod/notulen-prepublish-service/releases/tag/v1.4.3