### PR TITLE
bump frontend from 2.20.6 to 2.21.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
     max-file: "3"
 services:
   editor:
-    image: lblod/frontend-gelinkt-notuleren:2.20.6
+    image: lblod/frontend-gelinkt-notuleren:2.21.0
     links:
       - identifier:backend
     restart: always


### PR DESCRIPTION
:bug: Bug Fix

    #244 Fixing production builds "out of memory" problems (@benjay10)

:house: Internal

    #243 Linting after upgrade 3.28 (@benjay10)
    #200 Internal/ember upgrade (@nvdk)
    #229 Bump nanoid from 3.1.29 to 3.2.0 (@dependabot[bot])
    #241 Bump follow-redirects from 1.14.7 to 1.14.8 (@dependabot[bot])
    #240 align both the browserlist and build targets (@nvdk)