### PR TITLE
added new route for notulen preview

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -252,6 +252,10 @@ defmodule Dispatcher do
     forward conn, [], "http://preimporter/extract-previews"
   end
 
+   post "/meeting-notes-previews" do
+    forward conn, [], "http://preimporter/meeting-notes-previews"
+  end
+
   match "/signing/*path" do
     forward conn, path, "http://preimporter/signing/"
   end


### PR DESCRIPTION
The new standard endpoint needs to be in the dispatcher
Related to https://github.com/lblod/frontend-gelinkt-notuleren/pull/249 and https://github.com/lblod/notulen-prepublish-service/pull/81