### PR TITLE
Bugfix: make sure that users who can publish can update the status of documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 
 
+## 2.9.0 (2022-03-14)
+
+#### :rocket: Enhancement
+* [#82](https://github.com/lblod/app-gelinkt-notuleren/pull/82) upgrade frontend to 2.21.1 ([@nvdk](https://github.com/nvdk))
+* [#81](https://github.com/lblod/app-gelinkt-notuleren/pull/81) added new route for notulen preview ([@lagartoverde](https://github.com/lagartoverde))
+
+#### Committers: 2
+- Niels V ([@nvdk](https://github.com/nvdk))
+- Oscar Rodriguez Villalobos ([@lagartoverde](https://github.com/lagartoverde))
+
 ## 2.8.7 (2022-02-25)
 
 #### :bug: Bug Fix

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -186,6 +186,7 @@ defmodule Acl.UserGroups.Config do
                         "http://mu.semte.ch/vocabularies/ext/VersionedBehandeling",
                         "http://mu.semte.ch/vocabularies/ext/signing/PublishedResource",
                         "http://redpencil.data.gift/vocabularies/tasks/Task",
+                        "http://mu.semte.ch/vocabularies/ext/DocumentContainer", # needed to update status on publishing decision/notulen
                       ],
                       inverse_predicates: %AllPredicates{}
                       } } ] },


### PR DESCRIPTION
add writing to document container to publication right.
this is required because we update the status of the linked containers when publishing an extract or the notulen