### PR TITLE
bump prepublisher to 1.6.0: bugfix notulen publication preview

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
     labels:
       - "logging=true"
   preimporter:
-    image: lblod/notulen-prepublish-service:1.5.0
+    image: lblod/notulen-prepublish-service:1.6.0
     environment: 
       TZ: "Europe/Brussels"
     restart: always


### PR DESCRIPTION
https://github.com/lblod/notulen-prepublish-service/releases/tag/v1.6.0