### PR TITLE
bump frontend to 2.22.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
     max-file: "3"
 services:
   editor:
-    image: lblod/frontend-gelinkt-notuleren:2.21.1
+    image: lblod/frontend-gelinkt-notuleren:2.22.0
     links:
       - identifier:backend
     restart: always


### PR DESCRIPTION
https://github.com/lblod/frontend-gelinkt-notuleren/releases/tag/v2.22.0
https://github.com/lblod/frontend-gelinkt-notuleren/pull/252 improved regulation search + removed images from output ([@nvdk](https://github.com/nvdk))
    https://github.com/lblod/frontend-gelinkt-notuleren/pull/249 Generate a final preview for the notulen taking into account public behandelings ([@lagartoverde](https://github.com/lagartoverde))