### PR TITLE
Setup migration for correctly annotating the last missing citation

### DIFF
--- a/config/migrations/20220406201747-add-citation-to-roadsign-template.sparql
+++ b/config/migrations/20220406201747-add-citation-to-roadsign-template.sparql
@@ -1,0 +1,88 @@
+
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/2deed136-94c2-47ec-a542-8746cd020579> a <http://mu.semte.ch/vocabularies/ext/Template>;
+    ?p ?o.
+  }
+};
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+<http://lblod.info/templates/2deed136-94c2-47ec-a542-8746cd020579> a <http://mu.semte.ch/vocabularies/ext/Template>;
+    <http://purl.org/dc/terms/title> "Besluit mobiliteit";
+    <http://purl.org/dc/terms/description> """<div class=\"mark-highlight-manual\">
+     Dit sjabloon is toepasbaar voor volgende besluittypen:<br>
+    Reglementen en verordeningen
+    <ul>
+      <li>Aanvullend reglement op het wegverkeer enkel m.b.t. gemeentewegen (niet in havengebied of speciale beschermingszones)</li>
+      <li>Aanvullend reglement op het wegverkeer m.b.t. één of meerdere gewestwegen</li>
+      <li>Aanvullend reglement op het wegverkeer m.b.t. gemeentewegen in havengebied</li>
+      <li>Aanvullend reglement op het wegverkeer m.b.t. gemeentewegen in speciale beschermingszones</li>
+      <li>Politiereglement</li>
+      <li>Tijdelijke politieverordening (op het wegverkeer)</li>
+    </ul><br>
+  </div>""";
+  <http://mu.semte.ch/vocabularies/core/uuid> "2deed136-94c2-47ec-a542-8746cd020579";
+  <http://mu.semte.ch/vocabularies/ext/activeInContext> <http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt>;
+  <http://mu.semte.ch/vocabularies/ext/disabledInContext> <http://data.vlaanderen.be/ns/besluit#Besluit>;
+  <http://mu.semte.ch/vocabularies/ext/templateContent> """
+<div property=\"prov:generated\" resource=\"http://data.lblod.info/id/besluiten/${generateUuid()}\" typeof=\"besluit:Besluit https://data.vlaanderen.be/id/concept/BesluitType/67378dd0-5413-474b-8996-d992ef81637a ext:BesluitNieuweStijl\">
+ <p>Openbare titel besluit:</p>
+ <h4 class=\"h4\" property=\"eli:title\" datatype=\"xsd:string\"><span class=\"mark-highlight-manual\">Geef titel besluit op</span></h4>
+ <span style=\"display:none;\" property=\"eli:language\" resource=\"http://publications.europa.eu/resource/authority/language/NLD\" typeof=\"skos:Concept\">&nbsp;</span>
+ <p>Korte openbare beschrijving:</p>
+ <p property=\"eli:description\" datatype=\"xsd:string\"><span class=\"mark-highlight-manual\">Geef korte beschrijving op</span></p>
+ <br>
+
+ <div property=\"besluit:motivering\" lang=\"nl\">
+   <p>
+     <span class=\"mark-highlight-manual\">geef bestuursorgaan op</span>,
+   </p>
+   <br>
+
+   <h5>Bevoegdheid</h5>
+    <ul class=\"bullet-list\">
+      <li><span class=\"mark-highlight-manual\">Rechtsgrond die bepaalt dat dit orgaan bevoegd is.</span></li>
+    </ul>
+    <br>
+
+   <h5>Juridische context</h5>
+   <ul class=\"bullet-list\">
+     <li><a href=\"https://codex.vlaanderen.be/doc/document/1009730\">Nieuwe gemeentewet</a>&nbsp;(KB 24/06/1988)</li>
+     <li>decreet <a class=\"annotation\" href=\"https://codex.vlaanderen.be/doc/document/1029017\" property=\"eli:cites\" typeof=\"eli:LegalExpression\">over het lokaal bestuur</a> van 22/12/2017</li>
+     <li>wet <a class=\"annotation\" href=\"https://codex.vlaanderen.be/doc/document/1009628\" property=\"eli:cites\" typeof=\"eli:LegalExpression\">betreffende de politie over het wegverkeer (wegverkeerswet - Wet van 16 maart 1968)</a></li>
+     <li>wegcode - Koninklijk Besluit <a class=\"annotation\" href=\"https://codex.vlaanderen.be/doc/document/1036242\" property=\"eli:cites\" typeof=\"eli:LegalExpression\">van 1 december 1975 houdende algemeen reglement op de politie van het wegverkeer en van het gebruik van de openbare weg.</a></li>
+     <li>code van de wegbeheerder - <a class=\"annotation\" href=\"https://codex.vlaanderen.be/doc/document/1035575\" property=\"eli:cites\" typeof=\"eli:LegalExpression\">ministerieel besluit van 11 oktober 1976 houdende de minimumafmetingen en de bijzondere plaatsingsvoorwaarden van de verkeerstekens</a></li>
+   </ul>
+   <br>
+   <em>specifiek voor aanvullende reglementen op het wegverkeer  (= politieverordeningen m.b.t. het wegverkeer voor wat betreft permanente of periodieke verkeerssituaties)</em>
+   <ul class=\"bullet-list\">
+     <li>decreet <a class=\"annotation\" href=\"https://codex.vlaanderen.be/doc/document/1016816\" property=\"eli:cites\" typeof=\"eli:LegalExpression\">betreffende de aanvullende reglementenop het wegverkeer en de plaatsing en bekostiging van de verkeerstekens </a>(16 mei 2008)</li>
+     <li>Besluit van de Vlaamse Regering <a class=\"annotation\" href=\"https://codex.vlaanderen.be/doc/document/1017729\" property=\"eli:cites\" typeof=\"eli:LegalExpression\">betreffende de aanvullende reglementen en de plaatsing en bekostiging van verkeerstekens</a>​ van 23 januari 2009</li>
+          <li><a href=\"https://codex.vlaanderen.be/doc/document/1035938\" property=\"eli:cites\" typeof=\"eli:LegalExpression\">Omzendbrief MOB/2009/01 van 3 april 2009 gemeentelijke aanvullende reglementen op de politie over het wegverkeer</a></li>
+   </ul>
+
+   <h5>Feitelijke context en argumentatie</h5>
+   <ul class=\"bullet-list\">
+     <li><span class=\"mark-highlight-manual\">Voeg context en argumentatie in</span></li>
+   </ul>
+ </div>
+ <br>
+ <br>
+
+ <h5>Beslissing</h5>
+
+ <div property=\"prov:value\" datatype=\"xsd:string\">
+   <div property=\"eli:has_part\" resource=\"http://data.lblod.info/artikels/bbeb89ae-998b-4339-8de4-c8ab3a0679b5\" typeof=\"besluit:Artikel\">
+     <div>Artikel <span property=\"eli:number\" datatype=\"xsd:string\">1</span></div>
+     <span style=\"display:none;\" property=\"eli:language\" resource=\"http://publications.europa.eu/resource/authority/language/NLD\" typeof=\"skos:Concept\">&nbsp;</span>
+     <div property=\"prov:value\" datatype=\"xsd:string\">
+       <span class=\"mark-highlight-manual\">Voer inhoud in</span>
+     </div>
+   </div>
+ </div>
+</div>
+""";
+<http://mu.semte.ch/vocabularies/ext/templateMatches> "Voeg sjabloon in voor besluit of vrij tekstveld (bijvoorbeeld voor een vraag, antwoord of tussenkomst)"
+
+}}

--- a/config/migrations/20220406201747-add-citation-to-roadsign-template.sparql
+++ b/config/migrations/20220406201747-add-citation-to-roadsign-template.sparql
@@ -48,7 +48,7 @@ INSERT DATA {
 
    <h5>Juridische context</h5>
    <ul class=\"bullet-list\">
-     <li><a href=\"https://codex.vlaanderen.be/doc/document/1009730\">Nieuwe gemeentewet</a>&nbsp;(KB 24/06/1988)</li>
+     <li><a class=\"annotation\" href=\"https://codex.vlaanderen.be/doc/document/1009730\" property=\"eli:cites\" typeof=\"eli:LegalExpression\">Nieuwe gemeentewet</a> (KB 24/06/1988)</li>
      <li>decreet <a class=\"annotation\" href=\"https://codex.vlaanderen.be/doc/document/1029017\" property=\"eli:cites\" typeof=\"eli:LegalExpression\">over het lokaal bestuur</a> van 22/12/2017</li>
      <li>wet <a class=\"annotation\" href=\"https://codex.vlaanderen.be/doc/document/1009628\" property=\"eli:cites\" typeof=\"eli:LegalExpression\">betreffende de politie over het wegverkeer (wegverkeerswet - Wet van 16 maart 1968)</a></li>
      <li>wegcode - Koninklijk Besluit <a class=\"annotation\" href=\"https://codex.vlaanderen.be/doc/document/1036242\" property=\"eli:cites\" typeof=\"eli:LegalExpression\">van 1 december 1975 houdende algemeen reglement op de politie van het wegverkeer en van het gebruik van de openbare weg.</a></li>


### PR DESCRIPTION
Migration for https://github.com/lblod/editor-templates/pull/5#pullrequestreview-934120915

Closes https://binnenland.atlassian.net/browse/GN-3261

Also fixes a longstanding typo in the annotation of the line above the new annotation: it had `eli.cites` instead of `eli:cites`.
