### PR TITLE
add type and identifier to document container

### DIFF
--- a/config/resources/master-editor.lisp
+++ b/config/resources/master-editor.lisp
@@ -23,9 +23,12 @@
                 (:created-on :datetime ,(s-prefix "pav:createdOn"))
                 (:updated-on :datetime ,(s-prefix "pav:lastUpdateOn"))
                 (:starred :boolean ,(s-prefix "tmp:starred"))
+                (:identifier :string ,(s-prefix "dct:identifier"))
                 (:origin :string ,(s-prefix "pav:providedBy"))) ;;de gemeente Niel
   :has-one `((editor-document :via ,(s-prefix "pav:previousVersion")
                               :as "previous-version")
+             (concept :via ,(s-prefix "dct:type")
+                   :as "type")
              (editor-document :via ,(s-prefix "pav:previousVersion")
                               :inverse t
                               :as "next-version")


### PR DESCRIPTION
add type and identifier. These can be used for the reference number and road type of aanvullend wegreglement from IRG, but can also be used for other identifiers and types later on. somewhat in doubt whether the type shouldn't be on the version (editorDocument) instead of the container.