### PR TITLE
Bump mu-cl-resources to 1.21.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
     labels:
       - "logging=true"
   resource:
-    image: semtech/mu-cl-resources:1.21.0
+    image: semtech/mu-cl-resources:1.21.1
     volumes:
       - ./config/resources:/config
     environment:


### PR DESCRIPTION
This PR updates mu-cl-resources to 1.21.1. Version 1.21.1 introduces the option to clear cache keys when resources are deleted. This solves a bug in which meetings where deleted from the triplestore, but the cache was not notified. Solves a large part of https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3569.