### PR TITLE
Regulatory statement publishing support

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -120,6 +120,7 @@ defmodule Acl.UserGroups.Config do
                         "http://mu.semte.ch/vocabularies/ext/VersionedNotulen",
                         "http://mu.semte.ch/vocabularies/ext/VersionedBesluitenLijst",
                         "http://mu.semte.ch/vocabularies/ext/VersionedBehandeling",
+                        "http://mu.semte.ch/vocabularies/ext/VersionedRegulatoryStatement",
                         "http://redpencil.data.gift/vocabularies/tasks/Task",
                         "http://mu.semte.ch/vocabularies/ext/TaskSolution",
                         "http://mu.semte.ch/vocabularies/ext/TasklistSolution",
@@ -184,6 +185,7 @@ defmodule Acl.UserGroups.Config do
                         "http://mu.semte.ch/vocabularies/ext/VersionedNotulen",
                         "http://mu.semte.ch/vocabularies/ext/VersionedBesluitenLijst",
                         "http://mu.semte.ch/vocabularies/ext/VersionedBehandeling",
+                        "http://mu.semte.ch/vocabularies/ext/VersionedRegulatoryStatement",
                         "http://mu.semte.ch/vocabularies/ext/signing/PublishedResource",
                         "http://redpencil.data.gift/vocabularies/tasks/Task",
                         "http://mu.semte.ch/vocabularies/ext/DocumentContainer", # needed to update status on publishing decision/notulen
@@ -242,7 +244,7 @@ defmodule Acl.UserGroups.Config do
                         "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer",
                         "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
                         "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer"
-                      ]}}]}, 
+                      ]}}]},
       # // CLEANUP
       #
       %GraphCleanup{

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -15,11 +15,11 @@ defmodule Dispatcher do
   get "/sync/files/*path" do
     forward conn, path, "http://published-resource-producer/files/"
   end
-  
+
   get "/files/:id/download" do
     Proxy.forward conn, [], "http://file/files/" <> id <> "/download"
   end
-  
+
   post "/files/*path" do
     Proxy.forward conn, path, "http://file/files/"
   end
@@ -107,7 +107,7 @@ defmodule Dispatcher do
   match "/stemmingen/*path" do
     forward conn, path, "http://cache/stemmingen/"
   end
-  
+
   delete "/zittingen/*path" do
     forward conn, path, "http://meeting/"
   end
@@ -292,6 +292,10 @@ defmodule Dispatcher do
     forward conn, path, "http://resource/versioned-notulen/"
   end
 
+  match "/versioned-reglementaire-bijlagen/*path" do
+    forward conn, path, "http://resource/versioned-reglementaire-bijlagen/"
+  end
+
   match "/blockchain-statuses/*path" do
     forward conn, path, "http://resource/blockchain-statuses/"
   end
@@ -396,7 +400,7 @@ defmodule Dispatcher do
   match "/query/*path" do
     forward conn, path, "http://yasgui/"
   end
-  
+
   match "/*_" do
     send_resp( conn, 404, "Route not found.  See config/dispatcher.ex" )
   end

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -292,8 +292,8 @@ defmodule Dispatcher do
     forward conn, path, "http://resource/versioned-notulen/"
   end
 
-  match "/versioned-reglementaire-bijlagen/*path" do
-    forward conn, path, "http://resource/versioned-reglementaire-bijlagen/"
+  match "/versioned-regulatory-statements/*path" do
+    forward conn, path, "http://resource/versioned-regulatory-statements/"
   end
 
   match "/blockchain-statuses/*path" do

--- a/config/resources/master-editor.lisp
+++ b/config/resources/master-editor.lisp
@@ -29,6 +29,8 @@
                               :as "previous-version")
              (concept :via ,(s-prefix "dct:type")
                    :as "type")
+             (concept :via ,(s-prefix "ext:editorDocumentStatus")
+                      :as "status")
              (editor-document :via ,(s-prefix "pav:previousVersion")
                               :inverse t
                               :as "next-version")

--- a/config/resources/slave-publicatie-gn-domain.lisp
+++ b/config/resources/slave-publicatie-gn-domain.lisp
@@ -84,6 +84,25 @@
   :features '(include-uri)
   :on-path "versioned-behandelingen")
 
+(define-resource versioned-reglementaire-bijlage ()
+  :class (s-prefix "ext:VersionedReglementaireBijlage")
+  :properties `((:state :string ,(s-prefix "ext:stateString"))
+                (:content :string ,(s-prefix "ext:content")))
+  :has-many `((signed-resource :via ,(s-prefix "ext:signsReglementaireBijlage")
+                               :inverse t
+                               :as "signed-resources"))
+  :has-one `((published-resource :via ,(s-prefix "ext:publishesReglementaireBijlage")
+                                 :inverse t
+                                 :as "published-resource")
+             (zitting :via ,(s-prefix "ext:hasVersionedReglementaireBijlage")
+                                 :inverse t
+                                 :as "zitting")
+             (editor-document :via ,(s-prefix "ext:reglementaireBijlage")
+                                         :as "reglementaireBijlage"))
+  :resource-base (s-url "http://data.lblod.info/prepublished-reglementaire-bijlage/")
+  :features '(include-uri)
+  :on-path "versioned-reglementaire-bijlagen")
+
 
 (define-resource signed-resource ()
   :class (s-prefix "sign:SignedResource")

--- a/config/resources/slave-publicatie-gn-domain.lisp
+++ b/config/resources/slave-publicatie-gn-domain.lisp
@@ -84,24 +84,24 @@
   :features '(include-uri)
   :on-path "versioned-behandelingen")
 
-(define-resource versioned-reglementaire-bijlage ()
-  :class (s-prefix "ext:VersionedReglementaireBijlage")
+(define-resource versioned-regulatory-statement ()
+  :class (s-prefix "ext:VersionedRegulatoryStatement")
   :properties `((:state :string ,(s-prefix "ext:stateString"))
                 (:content :string ,(s-prefix "ext:content")))
-  :has-many `((signed-resource :via ,(s-prefix "ext:signsReglementaireBijlage")
+  :has-many `((signed-resource :via ,(s-prefix "ext:signsRegulatoryStatement")
                                :inverse t
                                :as "signed-resources"))
-  :has-one `((published-resource :via ,(s-prefix "ext:publishesReglementaireBijlage")
+  :has-one `((published-resource :via ,(s-prefix "ext:publishesRegulatoryStatement")
                                  :inverse t
                                  :as "published-resource")
-             (versioned-behandeling :via ,(s-prefix "ext:hasVersionedReglementaireBijlage")
+             (versioned-behandeling :via ,(s-prefix "ext:hasVersionedRegulatoryStatement")
                                  :inverse t
                                  :as "versioned-behandeling")
-             (editor-document :via ,(s-prefix "ext:reglementaireBijlage")
-                                         :as "reglementaireBijlage"))
-  :resource-base (s-url "http://data.lblod.info/prepublished-reglementaire-bijlage/")
+             (editor-document :via ,(s-prefix "ext:regulatoryStatement")
+                                         :as "regulatoryStatement"))
+  :resource-base (s-url "http://data.lblod.info/prepublished-regulatory-statement/")
   :features '(include-uri)
-  :on-path "versioned-reglementaire-bijlagen")
+  :on-path "versioned-regulatory-statements")
 
 
 (define-resource signed-resource ()

--- a/config/resources/slave-publicatie-gn-domain.lisp
+++ b/config/resources/slave-publicatie-gn-domain.lisp
@@ -94,9 +94,9 @@
   :has-one `((published-resource :via ,(s-prefix "ext:publishesReglementaireBijlage")
                                  :inverse t
                                  :as "published-resource")
-             (zitting :via ,(s-prefix "ext:hasVersionedReglementaireBijlage")
+             (versioned-behandeling :via ,(s-prefix "ext:hasVersionedReglementaireBijlage")
                                  :inverse t
-                                 :as "zitting")
+                                 :as "versioned-behandeling")
              (editor-document :via ,(s-prefix "ext:reglementaireBijlage")
                                          :as "reglementaireBijlage"))
   :resource-base (s-url "http://data.lblod.info/prepublished-reglementaire-bijlage/")


### PR DESCRIPTION
This PR includes support for publishing regulatory statements:
- A `versioned-regulatory-statement` resource has been added which is linked to a specific version of a regulatory statement (an `editor-document`) and to a `versioned-behandeling`.
- A publication status has been added to the `editor-document` resource as we want to reflect which specific versions of a regulatory statement have been published.