### PR TITLE
bump migrations service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     labels:
       - "logging=true"
   migrations:
-    image: semtech/mu-migrations-service:0.7.0
+    image: semtech/mu-migrations-service:0.8.0
     links:
       - virtuoso:database
     volumes:


### PR DESCRIPTION
the old migration service (0.7.0) had a odd batch size, which is not inline with the typical virtuoso config
see also: https://github.com/mu-semtech/mu-migrations-service/pull/15