### PR TITLE
Update mu-cl-resources with case-insensitive sort feature

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
     labels:
       - "logging=true"
   resource:
-    image: semtech/mu-cl-resources:1.21.1
+    image: semtech/mu-cl-resources:feature-case-insensitive-sort
     volumes:
       - ./config/resources:/config
     environment:


### PR DESCRIPTION
This adds the option to sort on specific attribute in a case-insensitive way.