### PR TITLE
GN-4355: Show signage of "reader" role in publication actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- user with `signer` (ondertekenaar) role can create a `PublishingLog` (logs signing/deletion of signature)
+
 ## [5.1.0] - 2023-06-18
 
 ### Changed

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -217,6 +217,7 @@ defmodule Acl.UserGroups.Config do
                         "http://mu.semte.ch/vocabularies/ext/VersionedBehandeling",
                         "http://mu.semte.ch/vocabularies/ext/signing/SignedResource",
                         "http://redpencil.data.gift/vocabularies/tasks/Task",
+                        "http://mu.semte.ch/vocabularies/ext/PublishingLog",
                       ],
                       inverse_predicates: %AllPredicates{}
                     } } ] },


### PR DESCRIPTION
### Overview
When a "reader"-role user signed something, it would not show in the history tab (publication-actions). The problem was not with viewing, but actual creation of this record.

This PR allows any "signer"-role to also create a PublishingLog.

##### connected issues and PRs:
- [GN-4355: Actions for the mock-user (role 'Lezer') aren't being logged under 'Publication actions'](https://binnenland.atlassian.net/browse/GN-4355)
- https://github.com/lblod/frontend-gelinkt-notuleren/pull/498 => this fixes the deletion of a signature for a document. All other signage/sign deletion should work without this PR.

### How to test/reproduce
1. start with an old setup (e.g. master)
2. mock-login to a reader-role ("lezer")
3. sign anything (e.g. agenda). Do this by creating a meeting, filling in the required fields (at least one agenda point) and pressing the right top button "Sign and Publish" (only appears if everything required is done for the meeting!)
4. Go to publication actions. The signing of the reader will not be present. It is also not present if you log in as a writer-role.

To test the fix, follow the exact same procedure.
In step `4.` the sign action will now appear in the list.

### Challenges/uncertainties
- I signed and deleted the signature of all types of things that can be signed. (as far as I could find: 3 agenda types, decision, extract and document)
- A user with the sign-role can now add any "PublishingLog", including ones that aren't about signing. I'm guessing this is fine (and hard to specify), but still important to keep in mind.
