### PR TITLE
GN-4441: Update notulen-prepublish-service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
     labels:
       - "logging=true"
   preimporter:
-    image: lblod/notulen-prepublish-service:2.0.0
+    image: lblod/notulen-prepublish-service:2.1.0
     environment: 
       TZ: "Europe/Brussels"
     restart: always


### PR DESCRIPTION
### Overview
Update notulen-prepublish-service. Now template comments will be removed when publishing documents.

### How to test/reproduce
Probably just like https://github.com/lblod/frontend-gelinkt-notuleren/pull/545 but without having to do override. If template comments are hidden, then it must work as expected.