### PR TITLE
Fix old failing migration of KBO's

### DIFF
--- a/config/migrations/2018/20180529101944-kbo-numbers-ocmw-via-kbo.ttl
+++ b/config/migrations/2018/20180529101944-kbo-numbers-ocmw-via-kbo.ttl
@@ -318,6 +318,6 @@
 <http://data.lblod.info/id/bestuurseenheden/50273e406d564825a81c47226da0055d55b4fd1cf92d8ac56d83e4d52822bad8> <http://mu.semte.ch/vocabularies/ext/kbonummer> "0212248074" .
 <http://data.lblod.info/id/bestuurseenheden/96b45b07fbef0e8ec38186813a2f9a7c509ca938c051a3c302861eb0aa6803e2> <http://purl.org/dc/terms/identifier> "0212189280" .
 <http://data.lblod.info/id/bestuurseenheden/96b45b07fbef0e8ec38186813a2f9a7c509ca938c051a3c302861eb0aa6803e2> <http://mu.semte.ch/vocabularies/ext/kbonummer> "0212189280" .
-<http://data.lblod.info/id/bestuurseenheden/1820266bfcf4c0c9cf62582e1d2e4f7295224cbe24726fde42fd9bd31c76e632> <http://purl.org/dc/terms/identifier>-"0212206801" .
-<http://data.lblod.info/id/bestuurseenheden/1820266bfcf4c0c9cf62582e1d2e4f7295224cbe24726fde42fd9bd31c76e632> <http://mu.semte.ch/vocabularies/ext/kbonummer>-"0212206801" .
+<http://data.lblod.info/id/bestuurseenheden/1820266bfcf4c0c9cf62582e1d2e4f7295224cbe24726fde42fd9bd31c76e632> <http://purl.org/dc/terms/identifier> "0212206801" .
+<http://data.lblod.info/id/bestuurseenheden/1820266bfcf4c0c9cf62582e1d2e4f7295224cbe24726fde42fd9bd31c76e632> <http://mu.semte.ch/vocabularies/ext/kbonummer> "0212206801" .
 <http://data.lblod.info/id/bestuurseenheden/3e077115eeb70b649d44e2ebbb218f2cfcac5d84e130c88584f0ec23f7cebbf9> <http://purl.org/dc/terms/identifier> "0212189577" .


### PR DESCRIPTION
### Overview
Migrations were failing locally and seemed that this was the source (invalid syntax). Because migration service stops when any migration fails, it is useful to fix.

Niels let us know it is indeed a fault and can be fixed.

In normal usage you don't come across this problem, as you start from an existing database in toLoad (which already contains this migration). But it does become a problem if you'd ever want to start from scratch.

