### PR TITLE
GN-4439: Fix missing mandatees - also import new data from ldb/mdb export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
 - add extra configuration explanation for loading a backup.
 
+### Fixed
+- GN-4439: also insert data in public graph that is new in mdb and ldb exports (intead of just changes). This fixes some missing data in `bestuursfunctieCodes` in QA, which was the reason for broken mandatees.
 ## [5.3.5] - 2023-08-07
 ### Changed
 

--- a/scripts/project/prepare-data-sync-migrations-ldb/run.sh
+++ b/scripts/project/prepare-data-sync-migrations-ldb/run.sh
@@ -45,13 +45,13 @@ INSERT {
     }
 }
 ;
+# here we want to only replace data or insert new data, never remove old data.
+
+# First delete triples that exist in the public graph and will be inserted again from temp-ingest-graph 
+# The difference here is that data not being overwritten bij temp-ingest-graph will stay in the public graph
 DELETE {
     GRAPH <http://mu.semte.ch/graphs/public> {
         ?s ?p ?old .
-    }
-} INSERT{
-    GRAPH <http://mu.semte.ch/graphs/public> {
-        ?s ?p ?new .
     }
 } WHERE {
     GRAPH <http://mu.semte.ch/graphs/temp-ingest-graph> {
@@ -65,7 +65,22 @@ DELETE {
     }
 }
 ;
-
+# Secondly, insert all related data to the public graph.
+# this will insert triples removed from the public graph in the above query 
+# and triples that are "new" (were not present in public graph before)
+INSERT{
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        ?s ?p ?new .
+    }
+} WHERE {
+    GRAPH <http://mu.semte.ch/graphs/temp-ingest-graph> {
+        ?s a ?type ; ?p ?new .
+        FILTER (?type IN (
+            <http://mu.semte.ch/vocabularies/ext/BestuursfunctieCode>
+            ))
+    }
+}
+;
 DELETE {
     GRAPH ?organizationalGraph {
         ?s ?p ?old .

--- a/scripts/project/prepare-data-sync-migrations-mdb/run.sh
+++ b/scripts/project/prepare-data-sync-migrations-mdb/run.sh
@@ -40,13 +40,13 @@ INSERT {
     }
 }
 ;
+# here we want to only replace data or insert new data, never remove old data.
+
+# First delete triples that exist in the public graph and will be inserted again from temp-ingest-graph 
+# The difference here is that data not being overwritten bij temp-ingest-graph will stay in the public graph
 DELETE {
     GRAPH <http://mu.semte.ch/graphs/public> {
         ?s ?p ?old .
-    }
-} INSERT{
-    GRAPH <http://mu.semte.ch/graphs/public> {
-        ?s ?p ?new .
     }
 } WHERE {
     GRAPH <http://mu.semte.ch/graphs/temp-ingest-graph> {
@@ -63,6 +63,25 @@ DELETE {
     }
 }
 ;
+# Secondly, insert all related data to the public graph.
+# this will insert triples removed from the public graph in the above query 
+# and triples that are "new" (were not present in public graph before)
+INSERT{
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        ?s ?p ?new .
+    }
+} WHERE {
+    GRAPH <http://mu.semte.ch/graphs/temp-ingest-graph> {
+        ?s a ?type ; ?p ?new .
+        FILTER (?type IN (
+            <http://mu.semte.ch/vocabularies/ext/BeleidsdomeinCode>,
+            <http://www.w3.org/ns/org#Membership>,
+            <http://data.vlaanderen.be/ns/mandaat#Fractie>,
+            <http://mu.semte.ch/vocabularies/ext/BestuursfunctieCode>
+            ))
+    }
+}
+
 EOF
 ((tstamp++))
 cat <<EOF > "$dir/$tstamp-ingest-exported-triples-2.sparql"

--- a/scripts/project/prepare-data-sync-migrations-mdb/run.sh
+++ b/scripts/project/prepare-data-sync-migrations-mdb/run.sh
@@ -81,7 +81,7 @@ INSERT{
             ))
     }
 }
-
+;
 EOF
 ((tstamp++))
 cat <<EOF > "$dir/$tstamp-ingest-exported-triples-2.sparql"


### PR DESCRIPTION
### Overview
Mandatees were missing from the frontend and didn't get loaded for some reason. The bug was traced to the fetch of `BestuursfunctieCode`'s, which had a few missing. Looking in the database, the `BestuursfunctieCode`'s that were needed were missing their `mu:uuid` (and sometimes also `skos:prefLabel`) triple. This meant that `mu-cl-resource` did not fetch these triples.

The export does contain the correct triples, including `mu:uuid`'s, but the query was written such that existing data would only be updated, no new data would ever be added (for these specific cases). This meant that the missing uuid would never get added, because it did not exist in the first place.
Note that it is by design that it does not do a full "reset" of the data. Old data that is not present in the export anymore should still stay in the app-gelinkt-notuleren database.

The fix entails to allow both updates to data AND insertion of new data. This way the missing `mu:uuid`s will be inserted.

The reason for them missing is unknown. This might have been an issue with playing around in QA, stopping containers without being careful or something related.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4439

### Setup
To test this, you'll want to actually import an mdb-export. [The readme](https://github.com/lblod/app-gelinkt-notuleren#external-delta-sync-experimental) explains how to do this.
And you'll need a database (or data) with the problem mentioned.

### How to test/reproduce
Some tricks:
- import an mdb-export by adding it to your migration (including a .graph file) *without* running the code that was changed here. That way the graph will stay intact in your database and you can query on it via yasgui or Facet browser. (or remove the line `CLEAR GRAPH <http://mu.semte.ch/graphs/temp-ingest-graph>` before running the migration)
- adjust to query to only use `BestuursfunctieCode`. This data is quite limited, so it can be seen easily what is happening. This is also where the main problem came from.
- The easiest to have a "faulty" state is to load a backup of the QA database, which has these missing uuid in for example 5ab0e9b8a3b2ca7c5e000011 (Gemeenteraadslid). If QA is fixed, you can still test this problem by deleting some needed data yourself (e.g. a mu:uuid).

To test the fix:
before: mandates don't get loaded for e.g. Roeselare. data like Gemeenteraadslid is missing skos:prefLabel and mu:uuid in public graph.

1. download a new export
2. run the queries (by running the script and letting the migrations do its thing or run the scripts yourself to get some feedback)
3. see that:
 - `BestuursfunctieCode`'s in the public graph now have a uuid and prefLabel
 - mandates get loaded in the frontend (e.g. Roeselare or Dilbeek).


### Challenges/uncertainties
- I did not check for problems in any of the other data, except for `BestuursfunctieCode`
- the delete query deletes less than 1000 triples, but the insert adds 30000 of them. This feels weird, as this means there is a lot of "new" data, as data that is "changed" is part of the first (delete) query. As far as I can see the query looks correct though.