### PR TITLE
Add comment: adres resource is missing mu:uuid on production

### DIFF
--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -1009,6 +1009,8 @@
   :on-path "contact-punten"
 )
 
+;; !! This resource has no `mu:uuid` defined in production (source is from ldb export)
+;; and might not work as expected !!
 (define-resource adres ()
   :class (s-prefix "locn:Address")
   :properties `((:busnummer :string ,(s-prefix "adres:Adresvoorstelling.busnummer"))


### PR DESCRIPTION
### Overview
Using 
```
SELECT  ?s ?type WHERE {
    GRAPH <http://mu.semte.ch/graphs/public> {
        ?s a ?type .
        MINUS {
      	?s <http://mu.semte.ch/vocabularies/core/uuid> ?a.
    }}}
```
It was checked if any resources missed a mu:uuid on production.
This is the case for the `adres` resource. This can be bad, as mu-cl-resources will not return these in a query because of this.
Note that `adres` is not used at all in GN, but does exist in the database. 

##### connected issues and PRs:
The reason for checking was because of mandatees not showing up because of a similar problem: #169 

### Challenges/uncertainties
Other possibilities:
- remove this from mu-cl-resources. But then we will definitely not know about the missing uuid when we do end up using this data.
- remove from mu-cl-resources *and* database. But as this is imported from ldb, this can be confusing.
