### PR TITLE
Set restart: no on some dev services and configure identifier cookies

### DIFF
--- a/.changeset/hip-dragons-wink.md
+++ b/.changeset/hip-dragons-wink.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Fix issues in dev for latest browsers

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,7 @@ services:
   dashboard:
     ports:
       - "82:80"
+    restart: "no"
   dashboard-identifier:
     ports:
       - "81:80"
@@ -13,11 +14,15 @@ services:
       - ./config/proxy:/etc/nginx/conf.d
     ports:
       - "443:443"
+  meeting:
+    restart: "no"
   editor:
     restart: "no"
   identifier:
     environment:
       SESSION_COOKIE_SECURE: "false"
+      # SAME_SITE: "None" doesn't work with insecure cookies
+      SESSION_COOKIE_SAME_SITE: "Lax"
     ports:
       - "80:80"
     restart: "no"
@@ -54,6 +59,8 @@ services:
     environment:
       ENABLE_ENDPOINT_SELECTOR: "true"
       DEFAULT_SPARQL_ENDPOINT: "http://localhost:8890/sparql"
+  file:
+    restart: "no"
   adressenregister:
     restart: "no"
   published-resource-producer:


### PR DESCRIPTION
### Overview
Make sure restarting of all services is switched off in dev. Configure identifier to no longer disallow same-site cookies in dev as it fails with insecure cookies in some browsers.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Start a dev cluster, go to mock-login in Firefox (>= 119.0b6) or chrome (not confirmed), log in, then attempt to reload the homepage. Before this change you are logged out, with this change you remain logged in.

Restart your docker daemon (systemctl restart docker if managing it with systemd in linux (with a --user flag if rootless)), confirm that none of the app-gelinkt-notuleren services have been started.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] changelog
