### PR TITLE
Update virtuoso image to redpencil/virtuoso:1.2.0-rc.1

### DIFF
--- a/.changeset/tiny-pots-smell.md
+++ b/.changeset/tiny-pots-smell.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Update virtuoso image to redpencil/virtuoso:1.2.0-rc.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     labels:
       - "logging=true"
   virtuoso:
-    image: tenforce/virtuoso:1.3.2-virtuoso7.2.5.1
+    image: redpencil/virtuoso:1.2.0-rc.1
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-gelinkt-notuleren",
-  "version": "5.5.0",
+  "version": "5.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app-gelinkt-notuleren",
-      "version": "5.5.0",
+      "version": "5.5.2",
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.8",
         "@changesets/cli": "^2.26.2",


### PR DESCRIPTION
### Overview
This PR updates the virtuoso image to redpencil/virtuoso:1.2.0-rc.1

When upgrading to this version, the `virtuoso.trx` needs to be deleted (after a back-up) as it is not compatible with the new version.

### How to test/reproduce
- delete the transaction file after a backup
- docker-compose up


### Checks PR readiness
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
