### PR TITLE
bump delta notifier for better error reporting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       SESSION_COOKIE_SECURE: "on"
       SESSION_COOKIE_SAME_SITE: "None"
   deltanotifier:
-    image: semtech/mu-delta-notifier:0.1.0
+    image: semtech/mu-delta-notifier:0.2.0
     volumes:
       - ./config/delta:/config
     restart: always


### PR DESCRIPTION
### Overview
bump delta notifier for better error reporting and (to be proven) slightly faster delta delivery.

##### connected issues and PRs:
None

### Setup
`docker-compose up -d`

### How to test/reproduce
Start app, do some changes check if delta's are sent. Creating a file via the file service would be a good test case

### Challenges/uncertainties
It's already in use in some production apps, so I don't expect any issues. Some errors might come to light because they're now actually logged in the containers' log. 

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] no new deprecations
