### PR TITLE
publication as files: handle larger publications correctly

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -224,27 +224,27 @@ defmodule Dispatcher do
   end
 
   match "/prepublish/*path" do
-    forward conn, path, "http://preimporter/prepublish/"
+    forward conn, path, "http://prepublish/prepublish/"
   end
 
 
   post "/extract-previews" do
-    forward conn, [], "http://preimporter/extract-previews"
+    forward conn, [], "http://prepublish/extract-previews"
   end
 
    post "/meeting-notes-previews" do
-    forward conn, [], "http://preimporter/meeting-notes-previews"
+    forward conn, [], "http://prepublish/meeting-notes-previews"
   end
 
   match "/signing/*path" do
-    forward conn, path, "http://preimporter/signing/"
+    forward conn, path, "http://prepublish/signing/"
   end
 
   match "/publication-tasks/*path" do
-    forward conn, path, "http://preimporter/publication-tasks/"
+    forward conn, path, "http://prepublish/publication-tasks/"
   end
   post "/signed-resources" do
-    forward conn, [], "http://preimporter/signed-resources/"
+    forward conn, [], "http://prepublish/signed-resources/"
   end
 
   match "/signed-resources/*path" do

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -564,6 +564,8 @@
   :has-one `((published-resource :via ,(s-prefix "ext:publishesNotulen")
                                  :inverse t
                                  :as "published-resource")
+             (file :via ,(s-prefix "prov:generated")
+                   :as "file")
              (editor-document :via ,(s-prefix "prov:wasDerivedFrom")
                               :as "editor-document")
              (zitting :via ,(s-prefix "ext:hasVersionedNotulen")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -46,7 +46,7 @@ services:
     restart: "no"
   resource:
     restart: "no"
-  preimporter:
+  prepublish:
     restart: "no"
   deltanotifier:
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,9 +124,9 @@ services:
     labels:
       - "logging=true"
   prepublish:
-#    image: lblod/notulen-prepublish-service:2.2.0
-    build:
-      context: https://github.com/lblod/notulen-prepublish-service#enhancement/better-support-for-large-content
+    image: lblod/notulen-prepublish-service:2.1.1
+    # build:
+    #   context: https://github.com/lblod/notulen-prepublish-service#enhancement/better-support-for-large-content
     environment:
       TZ: "Europe/Brussels"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
         max-file: "3"
     labels:
       - "logging=true"
-  preimporter:
+  prepublish:
     image: lblod/notulen-prepublish-service:2.1.1
     environment:
       TZ: "Europe/Brussels"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,9 @@ services:
     labels:
       - "logging=true"
   prepublish:
-    image: lblod/notulen-prepublish-service:2.1.1
+#    image: lblod/notulen-prepublish-service:2.2.0
+    build:
+      context: https://github.com/lblod/notulen-prepublish-service#enhancement/better-support-for-large-content
     environment:
       TZ: "Europe/Brussels"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     labels:
       - "logging=true"
   editor:
-    image: lblod/frontend-gelinkt-notuleren:5.11.0
+    image: lblod/frontend-gelinkt-notuleren:5.12.0
     links:
       - identifier:backend
     restart: always
@@ -124,7 +124,7 @@ services:
     labels:
       - "logging=true"
   prepublish:
-    image: lblod/notulen-prepublish-service:2.1.1
+    image: lblod/notulen-prepublish-service:2.2.0
     # build:
     #   context: https://github.com/lblod/notulen-prepublish-service#enhancement/better-support-for-large-content
     environment:
@@ -149,7 +149,7 @@ services:
     labels:
       - "logging=true"
   published-resource-producer:
-    image: lblod/published-resource-producer:1.1.2
+    image: lblod/published-resource-producer:1.2.0
     volumes:
       - ./data/files:/share
     environment:


### PR DESCRIPTION
### Overview
Introduces some updates to the publication flow, specifically for notulen content will be saved as a file instead of a string in the database.

##### connected issues and PRs:

### Setup
- checkout this branch
- run frontend on branch [feature/notulen-content-as-file](https://github.com/lblod/frontend-gelinkt-notuleren/tree/feature/notulen-content-as-file)
- run producer service from PR: https://github.com/lblod/published-resource-producer/pull/5
- run prepublisher service from PR: https://github.com/lblod/notulen-prepublish-service/pull/75
- run publication stack with:
  - consumer service from https://github.com/lblod/gelinkt-notuleren-consumer/pull/2
  - besluit-publicatie servce from https://github.com/lblod/besluit-publicatie-publish-service/pull/12

### How to test/reproduce
With everything hooked up, make a new meeting and publish the notulen. verify everything flows through and the notulen shows up correctly in the publication stack. If you need help to link stacks together or setup the services, send me a message

### Challenges/uncertainties
Producer still needs to be updated to include this extra file information, might want to upgrade to the generic producer service.


### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] no new deprecations
