### PR TITLE
GN-4744: remove unresolvable `report-content` relationship

### DIFF
--- a/.changeset/wicked-grapes-act.md
+++ b/.changeset/wicked-grapes-act.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Remove unresolvable `report-content` raltionship from `log-entry` model

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -1185,8 +1185,6 @@
                    :as "status-code")
               (log-source :via ,(s-prefix "dct:source")
                    :as "log-source"))
-  :has-many `((report-content :via ,(s-prefix "ext:belongsToReport")
-                   :as "report-content"))
   :resource-base (s-url "http://data.lblod.info/id/log-entries/")
   :features `(include-uri)
   :on-path "log-entries"


### PR DESCRIPTION
### Overview
The recent update to `mu-cl-resources` 1.23.0 includes some changes in the handling of undefined resource models.
This PR ensures that relationships pointing to undefined models are removed.

##### connected issues and PRs:
[GN-4744](https://binnenland.atlassian.net/browse/GN-4744)

### How to test/reproduce
- Set-up the stack
- Open up the frontend
- Create a meeting and add an agendapoint
- Notice that you can remove the agendapoint without any issues

### Challenges/uncertainties
To test if there are no undefined/unresolvable resources/relationships in the resource definitions, you can run `mu project doc` and verify if it executes without any errors.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
