### PR TITLE
Remove unused adressenregister-fuzzy-search-service

### DIFF
--- a/.changeset/eight-schools-breathe.md
+++ b/.changeset/eight-schools-breathe.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Remove unused adressenregister-fuzzy-search-service

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -216,17 +216,9 @@ defmodule Dispatcher do
     forward conn, path, "http://cache/publishing-logs/"
   end
 
-  #################################################################
-  # Adressenregister
-  #################################################################
-  match "/adressenregister/*path" do
-    forward conn, path, "http://adressenregister/"
-  end
-
   match "/prepublish/*path" do
     forward conn, path, "http://prepublish/prepublish/"
   end
-
 
   post "/extract-previews" do
     forward conn, [], "http://prepublish/extract-previews"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -61,8 +61,6 @@ services:
       DEFAULT_SPARQL_ENDPOINT: "http://localhost:8890/sparql"
   file:
     restart: "no"
-  adressenregister:
-    restart: "no"
   published-resource-producer:
     restart: "no"
   codex-proxy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,12 +142,6 @@ services:
       - database:database
     volumes:
       - ./data/files/:/share/
-  adressenregister:
-    image: lblod/adressenregister-fuzzy-search-service:0.5.0
-    restart: always
-    logging: *default-logging
-    labels:
-      - "logging=true"
   published-resource-producer:
     image: lblod/published-resource-producer:1.2.0
     volumes:


### PR DESCRIPTION
### Overview
The version we were using uses a deactivated version of the API, so if we were still using it, we would have seen error on production ([see the discussion](https://chat.semte.ch/group/lblod-all?msg=RzGEc5TvnGLraipbg)). All our usage of this API is now done directly and uses the v2 (working) version of that API.

##### connected issues and PRs:
https://chat.semte.ch/group/lblod-all?msg=RzGEc5TvnGLraipbg

### Setup
N/A

### How to test/reproduce
Any address lookups still work (e.g. address variable plugin).

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
