### PR TITLE
Add lmb-proxy service

### DIFF
--- a/.changeset/gentle-crabs-tell.md
+++ b/.changeset/gentle-crabs-tell.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Add lmb-proxy service

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -329,15 +329,15 @@ defmodule Dispatcher do
     forward conn, path, "http://agendapoint-service/"
   end
 
-  options "/lmb-proxy/*path", _ do
+  options "/vendor-proxy/*path", _ do
     conn
     |> Plug.Conn.put_resp_header( "access-control-allow-headers", "content-type,accept" )
     |> Plug.Conn.put_resp_header( "access-control-allow-methods", "*" )
     |> send_resp( 200, "{ \"message\": \"ok\" }" )
   end
 
-  match "/lmb-proxy/*path" do
-    forward conn, path, "http://lmb-proxy/"
+  match "/vendor-proxy/*path" do
+    forward conn, path, "http://vendor-proxy/"
   end
   
   

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -329,6 +329,19 @@ defmodule Dispatcher do
     forward conn, path, "http://agendapoint-service/"
   end
 
+  options "/lmb-proxy/*path", _ do
+    conn
+    |> Plug.Conn.put_resp_header( "access-control-allow-headers", "content-type,accept" )
+    |> Plug.Conn.put_resp_header( "access-control-allow-methods", "*" )
+    |> send_resp( 200, "{ \"message\": \"ok\" }" )
+  end
+
+  match "/lmb-proxy/*path" do
+    forward conn, path, "http://lmb-proxy/"
+  end
+  
+  
+
   #########
   # login
   ########
@@ -351,6 +364,8 @@ defmodule Dispatcher do
   post "/remote-login/*path" do
     forward conn, [], "http://remotelogin/remote-login"
   end
+
+  
 
   match "/query/*path" do
     forward conn, path, "http://yasgui/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,3 +216,5 @@ services:
     logging: *default-logging
     labels:
       - "logging=true"
+  lmb-proxy:
+    image: lblod/lmb-sparql-proxy:0.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,4 +217,6 @@ services:
     labels:
       - "logging=true"
   lmb-proxy:
-    image: lblod/lmb-sparql-proxy:0.0.1
+    image: !reset null
+    build: https://github.com/lblod/lmb-proxy-service.git
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,7 +216,12 @@ services:
     logging: *default-logging
     labels:
       - "logging=true"
-  lmb-proxy:
+  vendor-proxy:
     image: !reset null
-    build: https://github.com/lblod/lmb-proxy-service.git
-    
+    build: https://github.com/lblod/vendor-proxy-service.git
+    environment:
+      QUERY_BASE_URL: 'https://mandatenbeheer.lblod.info'
+      VENDOR_KEY: 'secret'
+      VENDOR_URI: 'http://data.lblod.info/vendors/75ad4503-1699-4e43-8cab-a494142ae571'
+      AUTH_GROUP: 'org'
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,8 +215,7 @@ services:
     labels:
       - "logging=true"
   vendor-proxy:
-    image: !reset null
-    build: https://github.com/lblod/vendor-proxy-service.git
+    image: lblod/vendor-proxy-service:0.1.0
     environment:
       QUERY_BASE_URL: 'https://mandatenbeheer.lblod.info'
       VENDOR_KEY: 'secret'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-gelinkt-notuleren",
-  "version": "5.7.4",
+  "version": "5.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app-gelinkt-notuleren",
-      "version": "5.7.4",
+      "version": "5.10.0",
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.8",
         "@changesets/cli": "^2.26.2",


### PR DESCRIPTION
### Overview
Added the lmb-proxy service in order to proxy requests to the LMB app of the add mandatee plugin, also this PR serves as a call to review the service that didn't have a branch as is a new service

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4830
https://github.com/lblod/lmb-proxy-service


### Setup
The service is not yet released so you will have to build it as a docker image, and also add a VENDOR_KEY property, if you don't know which key should this be set to ask me in ricket chat



### Challenges/uncertainties
Not sure how error resilient should this be but I will put it in draft as I want to add more error handling to the service



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
