### PR TITLE
Update dev compose to give access to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository harvest three setups.  The base of these setups resides in the s
 * *docker-compose.yml* This provides you with the backend components.  There is a frontend application included which you can publish using a separate proxy (we tend to put a letsencrypt proxy in front).
 * *docker-compose.dev.yml* Provides changes for a good frontend development setup.
   - publishes the backend services on port 80 directly, so you can run `ember serve --proxy http://localhost` when developing the frontend apps natively.
+  - publishes the included frontend on port 83, so you can visit the app at http://localhost:83/
   - publishes the database instance on port 8890 so you can easily see what content is stored in the base triplestore
   - provides a mock-login backend service so you don't need the ACM/IDM integration.
 * *docker-compose.demo.yml* Provides a setup for demo purposes.  It is similar to the dev setup, but publishes the frontend application directly:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,6 +18,10 @@ services:
     restart: "no"
   editor:
     restart: "no"
+    ports:
+      - "83:80"
+    environment:
+      EMBER_ENVIRONMENT_NAME: "local"
   identifier:
     environment:
       SESSION_COOKIE_SECURE: "false"


### PR DESCRIPTION
### Overview
I realised that without `docker-compose.override.yml` tweaks, the default dev stack frontend is not accessible, which means that to test it you either need a local frontend (which isn't production-like) or to know the right overrides. 

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Move or comment out your override.yml, then `drc -f docker-compose.yml -f docker-compose.dev.yml up` and see that you can access the frontend on port 83.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] no new deprecations
