### PR TITLE
Set-up basic 'installatievergadering' data-model in order to represent installation meetings

### DIFF
--- a/.changeset/grumpy-cups-bathe.md
+++ b/.changeset/grumpy-cups-bathe.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Set-up basic 'installatievergadering' (derived from 'zitting') resource-model in order to represent installation meetings

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -108,6 +108,10 @@ defmodule Dispatcher do
     forward conn, path, "http://cache/zittingen/"
   end
 
+  match "/installatievergaderingen/*path" do
+    forward conn, path, "http://cache/installatievergaderingen/"
+  end
+
   match "/fracties/*path" do
     forward conn, path, "http://resource/fracties/"
   end

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -458,6 +458,17 @@
   :on-path "intermissions"
 )
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; INSTALLATION MEETING MODELS ;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-resource installatievergadering (zitting)
+  :class (s-prefix "ext:Installatievergadering")
+  :resource-base (s-url "http://data.lblod.info/id/installatievergaderingen/")
+  :features '(include-uri)
+  :on-path "installatievergaderingen"
+)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; PUBLICATION MODELS ;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
### Overview
This PR adds a basic `installatievergadering` data-model to the mu-cl-resources config. 'installatievergadering' derives from the existing `zitting` model.
Additionally, this PR also adds an `/installatievergaderingen` endpoint.

##### connected issues and PRs:
[GN-4828](https://binnenland.atlassian.net/browse/GN-4828)
https://github.com/lblod/frontend-gelinkt-notuleren/pull/683

### Setup
This PR should be tested in combination with https://github.com/lblod/frontend-gelinkt-notuleren/pull/683

### How to test/reproduce
Check-out https://github.com/lblod/frontend-gelinkt-notuleren/pull/683 for instructions on how to test this PR.

### Challenges/uncertainties
Currently, the new data-model introduced in this PR uses the `ext:Installatievergadering` type. This should probably change in the future.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
