### PR TITLE
Add dispatcher routes for static serving the frontend

### DIFF
--- a/.changeset/sixty-masks-share.md
+++ b/.changeset/sixty-masks-share.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Update frontend to version 5.20.1

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -367,7 +367,20 @@ defmodule Dispatcher do
     forward conn, path, "http://yasgui/"
   end
 
-  match "/*_" do
-    send_resp( conn, 404, "Route not found.  See config/dispatcher.ex" )
+  ###############################################################
+  # frontend layer
+  ###############################################################
+
+  match "/assets/*path" do
+    Proxy.forward conn, path, "http://editor/assets/"
   end
+
+  match "/@appuniversum/*path" do
+    Proxy.forward conn, path, "http://editor/@appuniversum/"
+  end
+
+  match "/*_path" do
+    Proxy.forward conn, [], "http://editor/index.html"
+  end
+  
 end

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,8 +18,6 @@ services:
     restart: "no"
   editor:
     restart: "no"
-    ports:
-      - "83:80"
     environment:
       EMBER_ENVIRONMENT_NAME: "local"
   identifier:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,7 @@ services:
     labels:
       - "logging=true"
   editor:
-    image: lblod/frontend-gelinkt-notuleren:5.20.0
-    links:
-      - identifier:backend
+    image: lblod/frontend-gelinkt-notuleren:static-3
     restart: always
     logging: *default-logging
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     labels:
       - "logging=true"
   editor:
-    image: lblod/frontend-gelinkt-notuleren:static-3
+    image: lblod/frontend-gelinkt-notuleren:5.20.1
     restart: always
     logging: *default-logging
     labels:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-gelinkt-notuleren",
-  "version": "5.16.0",
+  "version": "5.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app-gelinkt-notuleren",
-      "version": "5.16.0",
+      "version": "5.17.0",
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.8",
         "@changesets/cli": "^2.26.2",


### PR DESCRIPTION
### Overview
Added routes for static serving the frontend due to some discussions on mu-semtech

##### connected issues and PRs:
None


### Setup
Build the frontend image of https://github.com/lblod/frontend-gelinkt-notuleren/pull/689 and add it to the docker-compose file, then test that everything works 

### Challenges/uncertainties
As I said in the other PR now the api endpoints are exposed to the user



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] no new deprecations

IMPORTANT: Do not merge with the change to the docker-compose.yml, I will leave it like this and with no changelog in order to not forget to change it to the version of the frontend when released
