### PR TITLE
GN-4909: support for inauguration meeting synchronization

### DIFF
--- a/.changeset/lucky-lobsters-cough.md
+++ b/.changeset/lucky-lobsters-cough.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Add `synchronized-on` property to `installatievergadering` model

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -129,7 +129,9 @@ defmodule Acl.UserGroups.Config do
                         "http://www.w3.org/ns/adms#Identifier",
                         "http://mu.semte.ch/vocabularies/ext/signing/SignedResource",
                         "http://mu.semte.ch/vocabularies/ext/signing/PublishedResource",
-                        "http://mu.semte.ch/vocabularies/ext/PublishingLog"
+                        "http://mu.semte.ch/vocabularies/ext/PublishingLog",
+                        "http://mu.semte.ch/vocabularies/ext/Installatievergadering",
+                        "http://mu.semte.ch/vocabularies/ext/InstallatievergaderingSynchronizationStatus",
                       ] } } ] },
 
       %GroupSpec{
@@ -164,7 +166,9 @@ defmodule Acl.UserGroups.Config do
                         "http://www.w3.org/ns/person#Person",
                         "http://data.vlaanderen.be/ns/persoon#Geboorte",
                         "http://www.w3.org/ns/adms#Identifier",
-                        "http://mu.semte.ch/vocabularies/ext/PublishingLog"
+                        "http://mu.semte.ch/vocabularies/ext/PublishingLog",
+                        "http://mu.semte.ch/vocabularies/ext/Installatievergadering",
+                        "http://mu.semte.ch/vocabularies/ext/InstallatievergaderingSynchronizationStatus",
                       ] } } ] },
 
       %GroupSpec{

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -112,6 +112,10 @@ defmodule Dispatcher do
     forward conn, path, "http://cache/installatievergaderingen/"
   end
 
+  match "/installatievergadering-synchronization-statuses/*path" do
+    forward conn, path, "http://cache/installatievergadering-synchronization-statuses/"
+  end
+
   match "/fracties/*path" do
     forward conn, path, "http://resource/fracties/"
   end

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -464,10 +464,21 @@
 
 (define-resource installatievergadering (zitting)
   :class (s-prefix "ext:Installatievergadering")
-  :properties `((:synchronized-on :datetime ,(s-prefix "ext:synchronizedOn")))
+  :has-one `((installatievergadering-synchronization-status :via ,(s-prefix "ext:synchronizationStatus")
+                    :as "synchronization-status"))
   :resource-base (s-url "http://data.lblod.info/id/installatievergaderingen/")
   :features '(include-uri)
   :on-path "installatievergaderingen"
+)
+
+(define-resource installatievergadering-synchronization-status ()
+  :class (s-prefix "ext:InstallatievergaderingSynchronizationStatus")
+  :properties `((:timestamp :datetime ,(s-prefix "ext:timestamp"))
+                (:success :boolean ,(s-prefix "ext:success"))
+                (:error-message :string ,(s-prefix "ext:errorMessage")))
+  :resource-base (s-url "http://data.lblod.info/id/installatievergadering-synchronization-statuses/")
+  :features '(include-uri)
+  :on-path "installatievergadering-synchronization-statuses"
 )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -464,6 +464,7 @@
 
 (define-resource installatievergadering (zitting)
   :class (s-prefix "ext:Installatievergadering")
+  :properties `((:synchronized-on :datetime ,(s-prefix "ext:synchronizedOn")))
   :resource-base (s-url "http://data.lblod.info/id/installatievergaderingen/")
   :features '(include-uri)
   :on-path "installatievergaderingen"


### PR DESCRIPTION
### Overview
This PR includes changes needed for the inauguration meeting synchronization to work.
It includes a change to the `Installatievergadering` model: it adds a relationship to an instance of `InstallatieVergaderingSynchronizationStatus`. 
`InstallatieVergaderingSynchronizationStatus` contains the following properties:
- timestamp: the last time the meeting was synchronized
- success: whether the last sync was successful
- errorMessage (optional): an optional error-message which describes a possible frontend error of the last sync

##### connected issues and PRs:
[GN-4909](https://binnenland.atlassian.net/browse/GN-4909)
https://github.com/lblod/frontend-gelinkt-notuleren/pull/694

### How to test/reproduce
Check-out https://github.com/lblod/frontend-gelinkt-notuleren/pull/694 on instructions on how to test this PR.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
