### PR TITLE
Add restart config for vendor-proxy service

### DIFF
--- a/.changeset/old-mice-bake.md
+++ b/.changeset/old-mice-bake.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Add restart config for vendor-proxy service

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -75,5 +75,7 @@ services:
     restart: "no"
   dashboard-login:
     restart: "no"
+  vendor-proxy:
+    restart: "no"
   lpdc-service:
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,7 +221,7 @@ services:
       VENDOR_KEY: 'secret'
       VENDOR_URI: 'http://data.lblod.info/vendors/75ad4503-1699-4e43-8cab-a494142ae571'
       AUTH_GROUP: 'org'
-
+    restart: always
   lpdc-service:
     image: lblod/api-proxy-service:1.0.1
     links:


### PR DESCRIPTION
### Overview
...

##### connected issues and PRs:
Related to problems on RB: https://github.com/lblod/frontend-reglementaire-bijlage/pull/269
From Jira issue: https://binnenland.atlassian.net/browse/GN-5018

### Setup
N/A

### How to test/reproduce
Start the stack without dev config, then restart docker daemon and verify that the vendor-proxy service is running.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] no new deprecations
