### PR TITLE
GN-5032: add migration which marks versioned-notulen as deleted if necessary

### DIFF
--- a/.changeset/quick-elephants-camp.md
+++ b/.changeset/quick-elephants-camp.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Add migration which marks `signed-notulen` resources as deleted if they are linked to signed resources which are marked as deleted

--- a/.changeset/warm-kiwis-bake.md
+++ b/.changeset/warm-kiwis-bake.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+bump frontend to [5.19.4](https://github.com/lblod/frontend-gelinkt-notuleren/releases/tag/v5.19.4)

--- a/config/migrations/20240906104711-delete-versioned-notulen.sparql
+++ b/config/migrations/20240906104711-delete-versioned-notulen.sparql
@@ -1,0 +1,25 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+DELETE {
+  GRAPH ?g {
+  	?versioned_notulen ext:deleted "false"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?versioned_notulen ext:deleted "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?versioned_notulen a ext:VersionedNotulen;
+                       ext:notulenKind 'full';
+                       ext:deleted "false"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.
+    ?signed_resource ext:signsNotulen ?versioned_notulen.
+    FILTER NOT EXISTS {
+        ?signed_resource ext:deleted "false"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     labels:
       - "logging=true"
   editor:
-    image: lblod/frontend-gelinkt-notuleren:5.19.3
+    image: lblod/frontend-gelinkt-notuleren:5.19.4
     links:
       - identifier:backend
     restart: always


### PR DESCRIPTION
### Overview
This PR adds a migration which marks `version-notulen` resources as deleted if they are only linked to signed resources which are marked as deleted.

##### connected issues and PRs:
[GN-5032](https://binnenland.atlassian.net/browse/GN-5032)
https://github.com/lblod/frontend-gelinkt-notuleren/pull/710

### Setup
Should be tested in combo with https://github.com/lblod/frontend-gelinkt-notuleren/pull/710

### How to test/reproduce
Check-out https://github.com/lblod/frontend-gelinkt-notuleren/pull/710. This PR ensures that existing `versioned-notulen` resources are marked as deleted if necessary.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
