### PR TITLE
Add restart config for ldes-client

### DIFF
--- a/.changeset/cold-news-change.md
+++ b/.changeset/cold-news-change.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Add restart config for ldes-client

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -81,9 +81,3 @@ services:
   ldes-client:
     restart: "no"
     command: "/bin/false" # overwrite when testing
-## add this to your override file
-#   environment:
-#     EXTRA_HEADERS: "{\"Authorization\": \"Basic blablablatokengoeshere==\"}"
-#     For the initial ingest, bypass mu auth. remove this after it's
-#     finished and restart the stack
-#     BYPASS_MU_AUTH: "true"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   dashboard:
     ports:
@@ -79,8 +78,10 @@ services:
     restart: "no"
   lpdc-service:
     restart: "no"
+  ldes-client:
+    restart: "no"
+    command: "/bin/false" # overwrite when testing
 ## add this to your override file
-# ldes-client:
 #   environment:
 #     EXTRA_HEADERS: "{\"Authorization\": \"Basic blablablatokengoeshere==\"}"
 #     For the initial ingest, bypass mu auth. remove this after it's

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,9 @@
+# services:
+  # Re-enable the ldes-client in testing instead of disabling it to conserve resources
+  # ldes-client:
+  #   command: !reset null
+  #   environment:
+  #     EXTRA_HEADERS: "{\"Authorization\": \"Basic blablablatokengoeshere==\"}"
+  #     # For the initial ingest, bypass mu auth. remove this after it's
+  #     # finished and restart the stack
+  #     # BYPASS_MU_AUTH: "true"

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,4 +1,36 @@
+# This file contains overrides that are useful for different development situations. These are
+# intended to be used at the same time as the docker-compose.dev.yml file.
+
+# Network for testing publications locally. Needs tweaked identifier config as well.
+# networks:
+#   shared-gn-pub:
+#     name: shared-gn-pub
+
 # services:
+  # Extra logging from mu-auth
+  # database:
+  #   environment:
+  #     LOG_ERRORS: "true"
+  #     LOG_ACCESS_RIGHTS: "true"
+
+  # Do not run migrations
+  # migrations:
+  #   volumes: !reset null
+
+  # Configure LPDC service authentication
+  # lpdc-service:
+  #   environment:
+  #     API_URL: "https://api.ipdc.tni-vlaanderen.be"
+  #     API_KEY: "some secret key"
+
+  # Identifier config to test publications locally. Needs matching network configuration.
+  # identifier:
+  #   networks:
+  #     default:
+  #     shared-gn-pub:
+  #       aliases:
+  #         - "identifier-gelinkt-notuleren"
+
   # Re-enable the ldes-client in testing instead of disabling it to conserve resources
   # ldes-client:
   #   command: !reset null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
-version: "3.4"
 x-logging: &default-logging
   driver: "json-file"
   options:
     max-size: "10m"
     max-file: "3"
+
 services:
   meeting:
     image: lblod/meeting-service:0.0.3
@@ -239,6 +239,7 @@ services:
     links:
       - database:database
       - virtuoso:virtuoso
+    restart: always
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/mandaten-staging"
       DIRECT_DATABASE_CONNECTION: "http://virtuoso:8890/sparql"


### PR DESCRIPTION
### Overview
I realised this was missing while adding overrides. I also included the more unusual move to add an example overrides file with the ldes-client example and some other ones that I have. This should help with anyone wanting to get set up with the repo in the future. These are in separate commits, so if there are any doubts, we can just include the restart config.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Start app-gn, without the d-c.dev.yml or d-c.override.yml, then restart your docker daemon, and see that the ldes-client service is running.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
