### PR TITLE
Add only article attr to templates

### DIFF
--- a/.changeset/slimy-mayflies-tan.md
+++ b/.changeset/slimy-mayflies-tan.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Add only article attribute to besluit templates

--- a/config/migrations/20241021143900-update-templates-to-detect-only-article.sparql
+++ b/config/migrations/20241021143900-update-templates-to-detect-only-article.sparql
@@ -1,0 +1,174 @@
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/39c31a7e-2ba9-11e9-88cf-83ebfda837dc> <http://mu.semte.ch/vocabularies/ext/templateContent> ?templateContent
+  }
+};
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+<http://lblod.info/templates/39c31a7e-2ba9-11e9-88cf-83ebfda837dc> <http://mu.semte.ch/vocabularies/ext/templateContent> """
+
+<div property="prov:generated" resource="http://data.lblod.info/id/besluiten/${generateUuid()}" typeof="besluit:Besluit ext:BesluitKlassiekeStijl">
+  <p>Openbare titel besluit:</p>
+  <h5 class="h4" property="eli:title" datatype="xsd:string"><span class="mark-highlight-manual">Geef openbare titel besluit op</span></h5>
+  <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
+  <br>
+  <p>Korte openbare beschrijving:</p>
+  <p property="eli:description" datatype="xsd:string"><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
+  <br>
+
+
+  <div property="besluit:motivering" lang="nl">
+    <p>
+      <span class="mark-highlight-manual">geef bestuursorgaan op</span>,
+    </p>
+    <br>
+
+    <div>
+      <ul class="bullet-list">
+        <li>Gelet op <span class="mark-highlight-manual">Voeg juridische grond in</span>;</li>
+      </ul>
+    </div>
+
+    <br>
+    <div>
+      <ul class="bullet-list">
+        <li>Overwegende dat <span class="mark-highlight-manual">Voeg motivering in</span>;</li>
+      </ul>
+    </div>
+  </div>
+  <br>
+  <br>
+
+  <p class="u-spacer--small">Beslist,</p>
+  <div property="prov:value" datatype="xsd:string">
+    <div property="eli:has_part" resource="http://data.lblod.info/artikels/${generateUuid()}" typeof="besluit:Artikel" data-say-is-only-article="true">
+      <div>Artikel <span property="eli:number" datatype="xsd:string">1</span></div>
+      <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
+      <div property="prov:value" datatype="xsd:string"><span class="mark-highlight-manual">Voer inhoud in</span></div>
+    </div>
+  </div>
+</div>
+
+""".
+}
+};
+
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/6933312e-2bac-11e9-af69-3baeff70b1a8> <http://mu.semte.ch/vocabularies/ext/templateContent> ?templateContent
+  }
+};
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+<http://lblod.info/templates/6933312e-2bac-11e9-af69-3baeff70b1a8> <http://mu.semte.ch/vocabularies/ext/templateContent> """
+
+<div property="prov:generated" resource="http://data.lblod.info/id/besluiten/${generateUuid()}" typeof="besluit:Besluit ext:BesluitNieuweStijl">
+        <p>Openbare titel besluit:</p>
+        <h4 class="h4" property="eli:title" datatype="xsd:string"><span class="mark-highlight-manual">Geef titel besluit op</span></h4>
+        <span style="display: none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span> <br />
+        <p>Korte openbare beschrijving:</p>
+        <p property="eli:description" datatype="xsd:string"><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
+        <br />
+        <div property="besluit:motivering" lang="nl">
+          <p><span class="mark-highlight-manual">geef bestuursorgaan op</span>,</p>
+          <br />
+          <h5>Bevoegdheid</h5>
+          <ul class="bullet-list">
+            <li><span class="mark-highlight-manual">Rechtsgrond die bepaalt dat dit orgaan bevoegd is.</span></li>
+          </ul>
+          <br />
+          <h5>Juridische context</h5>
+          <ul class="bullet-list">
+            <li><span class="mark-highlight-manual">Voeg juridische context in</span></li>
+          </ul>
+          <br />
+          <h5>Feitelijke context en argumentatie</h5>
+          <ul class="bullet-list">
+            <li><span class="mark-highlight-manual">Voeg context en argumentatie in</span></li>
+          </ul>
+        </div>
+        <br />
+        <br />
+        <h5>Beslissing</h5>
+        <div property="prov:value" datatype="xsd:string">
+          <div property="eli:has_part" resource="http://data.lblod.info/artikels/${generateUuid()}" typeof="besluit:Artikel" data-say-is-only-article="true">
+            <div>Artikel <span property="eli:number" datatype="xsd:string">1</span></div>
+            <span style="display: none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
+            <div property="prov:value" datatype="xsd:string"><span class="mark-highlight-manual">Voer inhoud in</span></div>
+          </div>
+        </div>
+      </div>
+
+""".
+}
+};
+
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/2deed136-94c2-47ec-a542-8746cd020579> <http://mu.semte.ch/vocabularies/ext/templateContent> ?templateContent
+  }
+};
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+<http://lblod.info/templates/2deed136-94c2-47ec-a542-8746cd020579> <http://mu.semte.ch/vocabularies/ext/templateContent> """
+
+<div property="prov:generated" resource="http://data.lblod.info/id/besluiten/${generateUuid()}" typeof="besluit:Besluit https://data.vlaanderen.be/id/concept/BesluitType/67378dd0-5413-474b-8996-d992ef81637a ext:BesluitNieuweStijl">
+ <p>Openbare titel besluit:</p>
+ <h4 class="h4" property="eli:title" datatype="xsd:string"><span class="mark-highlight-manual">Geef titel besluit op</span></h4>
+ <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
+ <p>Korte openbare beschrijving:</p>
+ <p property="eli:description" datatype="xsd:string"><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
+ <br>
+
+ <div property="besluit:motivering" lang="nl">
+   <p>
+     <span class="mark-highlight-manual">geef bestuursorgaan op</span>,
+   </p>
+   <br>
+
+   <h5>Bevoegdheid</h5>
+    <ul class="bullet-list">
+      <li><span class="mark-highlight-manual">Rechtsgrond die bepaalt dat dit orgaan bevoegd is.</span></li>
+    </ul>
+    <br>
+
+   <h5>Juridische context</h5>
+   <ul class="bullet-list">
+     <li><a class="annotation" property="eli:cites" typeof="eli:LegalExpression" href="https://codex.vlaanderen.be/doc/document/1009730">Nieuwe gemeentewet</a>&nbsp;(KB 24/06/1988)</li>
+     <li>decreet <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1029017" property="eli:cites" typeof="eli:LegalExpression">over het lokaal bestuur</a> van 22/12/2017</li>
+     <li>wet <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1009628" property="eli:cites" typeof="eli:LegalExpression">betreffende de politie over het wegverkeer (wegverkeerswet - Wet van 16 maart 1968)</a></li>
+     <li>wegcode - Koninklijk Besluit <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1036242" property="eli:cites" typeof="eli:LegalExpression">van 1 december 1975 houdende algemeen reglement op de politie van het wegverkeer en van het gebruik van de openbare weg.</a></li>
+     <li>code van de wegbeheerder - <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1035575" property="eli:cites" typeof="eli:LegalExpression">ministerieel besluit van 11 oktober 1976 houdende de minimumafmetingen en de bijzondere plaatsingsvoorwaarden van de verkeerstekens</a></li>
+   </ul>
+   <br>
+   <em>specifiek voor aanvullende reglementen op het wegverkeer  (= politieverordeningen m.b.t. het wegverkeer voor wat betreft permanente of periodieke verkeerssituaties)</em>
+   <ul class="bullet-list">
+     <li>decreet <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1016816" property="eli:cites" typeof="eli:LegalExpression">betreffende de aanvullende reglementen op het wegverkeer en de plaatsing en bekostiging van de verkeerstekens </a>(16 mei 2008)</li>
+     <li>Besluit van de Vlaamse Regering <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1017729" property="eli:cites" typeof="eli:LegalExpression">betreffende de aanvullende reglementen en de plaatsing en bekostiging van verkeerstekens</a>​ van 23 januari 2009</li>
+          <li><a href="https://codex.vlaanderen.be/doc/document/1035938" property="eli:cites" typeof="eli:LegalExpression">Omzendbrief MOB/2009/01 van 3 april 2009 gemeentelijke aanvullende reglementen op de politie over het wegverkeer</a></li>
+   </ul>
+
+   <h5>Feitelijke context en argumentatie</h5>
+   <ul class="bullet-list">
+     <li><span class="mark-highlight-manual">Voeg context en argumentatie in</span></li>
+   </ul>
+ </div>
+ <br>
+ <br>
+
+ <h5>Beslissing</h5>
+
+ <div property="prov:value" datatype="xsd:string">
+   <div property="eli:has_part" resource="http://data.lblod.info/artikels/${generateUuid()}" typeof="besluit:Artikel" data-say-is-only-article="true">
+     <div>Artikel <span property="eli:number" datatype="xsd:string">1</span></div>
+     <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
+     <div property="prov:value" datatype="xsd:string">
+       <span class="mark-highlight-manual">Voer inhoud in</span>
+     </div>
+   </div>
+ </div>
+</div>
+
+""".
+}
+};


### PR DESCRIPTION
### Overview
Add the data-say-is-only-article attribute in order to correctly show enig article in the templates

##### connected issues and PRs:
GN-5113
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/490


### Setup
You will need to link the plugins to the frontend with this https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/490 to test

### How to test/reproduce
Go to the frontend, insert any besluit template and the article title should be enig article instead of article 1

### Challenges/uncertainties
Tried to add a comment to better explain the attr for future modifications but I think is clear enough and better to leave no comment than a bad comment, let me know if you think otherwise



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
