### PR TITLE
data(migrations): add migration which renames some fusiegemeenten

### DIFF
--- a/.changeset/poor-snails-help.md
+++ b/.changeset/poor-snails-help.md
@@ -1,0 +1,8 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Add migration which updates the names of the following 'fusiegemeenten':
+'Bilzen' -> 'Bilzen-Hoeselt'
+'Tongeren' -> 'Tongeren-Borgloon'
+'Ham' -> 'Tessenderlo-Ham'

--- a/config/migrations/2024/2024-10/20241025073954-update-names-fusiegemeenten.sparql
+++ b/config/migrations/2024/2024-10/20241025073954-update-names-fusiegemeenten.sparql
@@ -1,0 +1,68 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX bestuurseenheidscode: <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/>
+
+DELETE {
+  GRAPH ?g {
+    ?bestuurseenheid skos:prefLabel ?eenheidsNaam .
+  }
+  GRAPH ?h {
+    ?orgaan skos:prefLabel ?orgaanNaam .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?bestuurseenheid skos:prefLabel ?eenheidsNaamNew .
+  }
+  GRAPH ?h {
+    ?orgaan skos:prefLabel ?orgaanNaamNew .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?bestuurseenheid a besluit:Bestuurseenheid ;
+      skos:prefLabel ?eenheidsNaam ;
+      besluit:classificatie ?bestuurseenheidscodes .
+    VALUES (?eenheidsNaam ?eenheidsNaamNew) { ("Bilzen" "Bilzen-Hoeselt") ("Tongeren" "Tongeren-Borgloon") ("Ham" "Tessenderlo-Ham") }
+    FILTER (?bestuurseenheidscodes IN ( bestuurseenheidscode:5ab0e9b8a3b2ca7c5e000001, bestuurseenheidscode:5ab0e9b8a3b2ca7c5e000002 ))
+  }
+  GRAPH ?h {
+    ?orgaan a besluit:Bestuursorgaan ;
+      besluit:bestuurt ?bestuurseenheid ;
+      skos:prefLabel ?orgaanNaam .
+  }
+  FILTER (STRENDS(?orgaanNaam, ?eenheidsNaam))
+  BIND (REPLACE(?orgaanNaam, ?eenheidsNaam, ?eenheidsNaamNew) AS ?orgaanNaamNew)
+};
+
+DELETE {
+  GRAPH ?g {
+    ?persoon foaf:familyName ?naam .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?persoon foaf:familyName ?naamNew .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?persoon a foaf:Person;
+      foaf:firstName ?classificatieLabel;
+      foaf:familyName ?naam;
+      foaf:account ?account.
+    ?account a foaf:OnlineAccount;
+      foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>.
+  }
+  VALUES (?naam ?naamNew) { 
+    ("Bilzen GelinktNotuleren-lezer" "Bilzen-Hoeselt GelinktNotuleren-lezer") 
+    ("Bilzen GelinktNotuleren-schrijver" "Bilzen-Hoeselt GelinktNotuleren-schrijver") 
+    ("Tongeren GelinktNotuleren-lezer" "Tongeren-Borgloon GelinktNotuleren-lezer") 
+    ("Tongeren GelinktNotuleren-schrijver" "Tongeren-Borgloon GelinktNotuleren-schrijver")
+    ("Ham GelinktNotuleren-lezer" "Tessenderlo-Ham GelinktNotuleren-lezer") 
+    ("Ham GelinktNotuleren-schrijver" "Tessenderlo-Ham GelinktNotuleren-schrijver")
+  }
+  FILTER (?classificatieLabel IN ( "Gemeente", "OCMW" ))
+}


### PR DESCRIPTION
### Overview
This PR adds a small migration which renames the following bestuurseenheden/bestuursorganen:
- "Bilzen" -> "Bilzen-Hoeselt"
- "Tongeren" -> "Tongeren-Borgloon"
- "Ham" -> "Tessenderlo-Ham"

##### connected issues and PRs:
[OP-3456](https://binnenland.atlassian.net/browse/OP-3456)

### Setup
None

### How to test/reproduce
- Start the virtuoso + migrations services
- Ensure the migrations run correctly
- Set-up the other services
- Ensure you can log-in with the renamed 'bestuurseenheden'

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
