### PR TITLE
Feat/expose sparql endpoint

### DIFF
--- a/.changeset/lemon-rockets-occur.md
+++ b/.changeset/lemon-rockets-occur.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Adjust `ldes-client/processPage.ts` to include a timestamp for each 'bestuurseenheid' which denotes the last LDES/LMB update

--- a/.changeset/perfect-readers-march.md
+++ b/.changeset/perfect-readers-march.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Expose /sparql and /raw-sparql endpoints for plugin consumption

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -384,6 +384,19 @@ defmodule Dispatcher do
     forward conn, [], "http://remotelogin/remote-login"
   end
 
+
+  #######################################################################
+  # SPARQL                                                              #
+  #######################################################################
+
+  match "/sparql" do
+    forward conn, [], "http://sparql-cache/sparql"
+  end
+
+  match "/raw-sparql" do
+    forward conn, [], "http://database:8890/sparql"
+  end
+
   
 
   match "/query/*path" do

--- a/config/ldes-client/processPage.ts
+++ b/config/ldes-client/processPage.ts
@@ -74,6 +74,34 @@ async function replaceExistingData() {
           ?s ?pOld ?oOld.
         }
       }
+    };
+    DELETE {
+      GRAPH <http://mu.semte.ch/graphs/lmb-data-public> {
+        ?administrativeUnit ext:lastLMBUpdate ?oldTimestamp.
+      }
+    }
+    INSERT {
+      GRAPH <http://mu.semte.ch/graphs/lmb-data-public> {
+        ?administrativeUnit ext:lastLMBUpdate ?newTimestamp.
+      }
+    }
+    WHERE {
+      {
+        SELECT ?administrativeUnit (MAX(?timestamp) as ?newTimestamp)
+        {
+          GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
+            ?stream <https://w3id.org/tree#member> ?versionedMember .
+            ?versionedMember ext:relatedTo ?administrativeUnit.
+            ?versionedMember ${sparqlEscapeUri(TIME_PREDICATE)} ?timestamp.
+          }
+        }
+        GROUP BY ?administrativeUnit
+      }
+      OPTIONAL {
+        GRAPH <http://mu.semte.ch/graphs/lmb-data-public> {
+          ?administrativeUnit ext:lastLMBUpdate ?oldTimestamp.
+        }
+      }
     }
   `
   await updateSudo(query, {}, options);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -251,3 +251,8 @@ services:
       LDES_BASE: "https:/dev.mandatenbeheer.lblod.info/streams/ldes/abb/"
     labels:
       - "logging=true"
+  sparql-cache:
+    image: redpencil/varnish-post:1.0.0
+    environment:
+      BACKEND_HOST: database
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     labels:
       - "logging=true"
   identifier:
-    image: semtech/mu-identifier:1.9.1
+    image: semtech/mu-identifier:1.10.3
     restart: always
     logging: *default-logging
     labels:


### PR DESCRIPTION
### Overview
Expose a endpoint to mu-auth, where the plugins from inside the application can query
Note that this doesn't mean the sparql endpoint is open, as we are querying to mu-auth with the proper restrictions

##### connected issues and PRs:
GN-5124


### Setup
None

### How to test/reproduce
Check that you can make sparql queries to both /sparql and /raw-sparql and you cannot access any sensitive data without auth

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
