### PR TITLE
data(migrations): re-initialize mock accounts for districten and fusiegemeenten 2025

### DIFF
--- a/.changeset/hip-schools-itch.md
+++ b/.changeset/hip-schools-itch.md
@@ -1,0 +1,6 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Add two migrations to correctly re-initialize mock accounts for 'districten' and 'fusiegemeenten 2025'.
+The re-initalization was necessary due to an error made related to account roles in the previous mock account migrations.

--- a/config/migrations/2024/2024-10/20241025073955-update-mock-accounts-districts.sparql
+++ b/config/migrations/2024/2024-10/20241025073955-update-mock-accounts-districts.sparql
@@ -1,0 +1,88 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX mu:<http://mu.semte.ch/vocabularies/core/>
+PREFIX ext:<http://mu.semte.ch/vocabularies/ext/>
+
+# - Reinitializes the mock accounts for districts (due to a mistake made related to roles)
+
+DELETE {
+  GRAPH ?g {
+    ?persoon a foaf:Person;
+      mu:uuid ?uuidPersoon;
+      foaf:firstName ?firstname;
+      foaf:familyName ?naam;
+      foaf:member ?bestuurseenheid;
+      foaf:account ?account.
+  }
+  GRAPH ?h {
+    ?account a foaf:OnlineAccount;
+      mu:uuid ?uuidAccount;
+      foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
+      ext:sessionRole ?role.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?persoon a foaf:Person;
+      mu:uuid ?uuidPersoon;
+      foaf:firstName ?firstname;
+      foaf:familyName ?naam;
+      foaf:member ?bestuurseenheid;
+      foaf:account ?account.
+  }
+  ?bestuurseenheid a besluit:Bestuurseenheid;
+    # Filter on district
+    besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003> .
+
+  GRAPH ?h {
+    ?account a foaf:OnlineAccount;
+      mu:uuid ?uuidAccount;
+      foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>.
+    OPTIONAL {
+      ?account ext:sessionRole ?role.
+    }
+  }
+};
+
+INSERT {
+  GRAPH ?orgGraph {
+    ?account a foaf:OnlineAccount;
+      mu:uuid ?uuidAccount;
+      foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>.
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?persoon a foaf:Person;
+      mu:uuid ?uuidPersoon;
+      foaf:firstName "District";
+      foaf:familyName ?naam;
+      foaf:member ?bestuurseenheid;
+      foaf:account ?account.
+    ?account a foaf:OnlineAccount;
+      mu:uuid ?uuidAccount;
+      foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
+      ext:sessionRole ?role ,"GelinktNotuleren-ondertekenaar", "GelinktNotuleren-publiceerder".
+  }
+  
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuurseenheid a besluit:Bestuurseenheid;
+        mu:uuid ?id ;
+        skos:prefLabel ?eenheidLabel ;
+        # Filter on district
+        besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003> .
+  }
+  VALUES ?role {
+     "GelinktNotuleren-schrijver"
+     "GelinktNotuleren-lezer"
+  }
+  BIND(CONCAT(?eenheidLabel, " ",  ?role) as ?naam)
+  BIND(CONCAT("District", " ", ?naam) as ?volledigeNaam)
+  BIND(MD5(?volledigeNaam) as ?uuidPersoon)
+  BIND(MD5(CONCAT(?volledigeNaam,"ACCOUNT")) as ?uuidAccount)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/persoon/", ?uuidPersoon)) AS ?persoon)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/account/", ?uuidAccount)) AS ?account)
+  BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", ?id)) AS ?orgGraph)
+}
+

--- a/config/migrations/2024/2024-10/20241025122025-update-mock-accounts-fusiegemeenten-2025.sparql
+++ b/config/migrations/2024/2024-10/20241025122025-update-mock-accounts-fusiegemeenten-2025.sparql
@@ -1,0 +1,108 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX mu:<http://mu.semte.ch/vocabularies/core/>
+PREFIX ext:<http://mu.semte.ch/vocabularies/ext/>
+
+# This migration re-initalizes the mock accounts for the following 'fusiegemeenten':
+# - Beveren-Kruibeke-Zwijndrecht
+# - Nazareth-De Pinte
+# - Pajottegem
+# - Merelbeke-Melle
+
+DELETE {
+  GRAPH ?g {
+    ?persoon a foaf:Person;
+      mu:uuid ?uuidPersoon;
+      foaf:firstName ?firstname;
+      foaf:familyName ?naam;
+      foaf:member ?bestuurseenheid;
+      foaf:account ?account.
+  }
+  GRAPH ?h {
+    ?account a foaf:OnlineAccount;
+      mu:uuid ?uuidAccount;
+      foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
+      ext:sessionRole ?role.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?persoon a foaf:Person;
+      mu:uuid ?uuidPersoon;
+      foaf:firstName ?firstname;
+      foaf:familyName ?naam;
+      foaf:member ?bestuurseenheid;
+      foaf:account ?account.
+  }
+  ?bestuurseenheid a besluit:Bestuurseenheid;
+    skos:prefLabel ?eenheidLabel.
+
+  VALUES ?eenheidLabel {
+      "Beveren-Kruibeke-Zwijndrecht"
+      "Nazareth-De Pinte"
+      "Pajottegem"
+      "Merelbeke-Melle"
+  }
+  GRAPH ?h {
+    ?account a foaf:OnlineAccount;
+      mu:uuid ?uuidAccount;
+      foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>.
+    OPTIONAL {
+      ?account ext:sessionRole ?role.
+    }
+  }
+};
+INSERT {
+  GRAPH ?orgGraph  {
+    ?account a foaf:OnlineAccount;
+      mu:uuid ?uuidAccount;
+      foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>.
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?persoon a foaf:Person;
+      mu:uuid ?uuidPersoon;
+      foaf:firstName ?classificatie;
+      foaf:familyName ?naam;
+      foaf:member ?bestuurseenheid;
+      foaf:account ?account.
+
+    ?account a foaf:OnlineAccount;
+      mu:uuid ?uuidAccount;
+      foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
+      ext:sessionRole ?role, "GelinktNotuleren-ondertekenaar", "GelinktNotuleren-publiceerder" .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?bestuurseenheid a besluit:Bestuurseenheid;
+      mu:uuid ?orgId;
+      skos:prefLabel ?eenheidLabel;
+      besluit:classificatie ?classificatieURI.
+    ?classificatieURI skos:prefLabel ?classificatie.
+     
+    VALUES ?eenheidLabel {
+      "Beveren-Kruibeke-Zwijndrecht"
+      "Nazareth-De Pinte"
+      "Pajottegem"
+      "Merelbeke-Melle"
+    }
+
+    VALUES ?role {
+      "GelinktNotuleren-schrijver"
+      "GelinktNotuleren-lezer"
+    }
+
+     BIND(<http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> as ?OCMW)
+     BIND(<http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> as ?gemeente)
+     FILTER(?classificatieURI IN (?OCMW, ?gemeente))
+
+     BIND(CONCAT(?eenheidLabel, " ",  ?role) as ?naam)
+     BIND(CONCAT(?classificatie, " ", ?naam) as ?volledigeNaam)
+     BIND(MD5(?volledigeNaam) as ?uuidPersoon)
+     BIND(MD5(CONCAT(?volledigeNaam,"ACCOUNT")) as ?uuidAccount)
+     BIND(IRI(CONCAT("http://data.lblod.info/id/persoon/", ?uuidPersoon)) AS ?persoon)
+     BIND(IRI(CONCAT("http://data.lblod.info/id/account/", ?uuidAccount)) AS ?account)
+     BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/",?orgId)) as ?orgGraph) 
+  }
+}


### PR DESCRIPTION
### Overview
An error related to account roles was included in previously created mock-account migrations for 'districten' and 'fusiegemeenten 2025'. 
The erroneous migrations:
- https://github.com/lblod/app-gelinkt-notuleren/blob/4c7d9cef54f22cc4e87e7f96aaa58e09c5408328/config/migrations/2024/2024-10/20241022085314-fusiegemeenten-2025/20241022085316-fusiegemeenten-mock-users.sparql
- https://github.com/lblod/app-gelinkt-notuleren/blob/4c7d9cef54f22cc4e87e7f96aaa58e09c5408328/config/migrations/2024/2024-10/20241022085311-districten/20241022085313-districten-mock-users.sparql

This PR re-initializes the mock accounts for 'districten' and 'fusiegemeenten 2025' to ensure the mock accounts have the correct roles.
For each 'bestuursorgaan', two accounts are created:
- One 'lezer' account
- One 'writer' account

### How to test/reproduce
- Start the virtuoso and migrations service
- Ensure the migrations have run successfully
- Start the other service
- Ensure you can login as a district or a new 'fusiegemeente'. 
  * https://www.vlaanderen.be/lokaal-bestuur/nieuwsberichten/groen-licht-voor-13-nieuwe-fusiegemeenten
  * https://www.antwerpen.be/info/5603bc8bafa8a75dd48b45aa/districten
- Ensure the correct roles are assigned to the logged in user. The list of roles should be one of these two:
  * "GelinktNotuleren-schrijver", "GelinktNotuleren-ondertekenaar", "GelinktNotuleren-publiceerder"
  * "GelinktNotuleren-lezer",  "GelinktNotuleren-ondertekenaar", "GelinktNotuleren-publiceerder"


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
