### PR TITLE
LMB LDES integration: keep track of 'last-update' timestamps for each administrative unit

### DIFF
--- a/.changeset/lemon-rockets-occur.md
+++ b/.changeset/lemon-rockets-occur.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Adjust `ldes-client/processPage.ts` to include a timestamp for each 'bestuurseenheid' which denotes the last LDES/LMB update

--- a/config/ldes-client/processPage.ts
+++ b/config/ldes-client/processPage.ts
@@ -74,6 +74,34 @@ async function replaceExistingData() {
           ?s ?pOld ?oOld.
         }
       }
+    };
+    DELETE {
+      GRAPH <http://mu.semte.ch/graphs/lmb-data-public> {
+        ?administrativeUnit ext:lastLMBUpdate ?oldTimestamp.
+      }
+    }
+    INSERT {
+      GRAPH <http://mu.semte.ch/graphs/lmb-data-public> {
+        ?administrativeUnit ext:lastLMBUpdate ?newTimestamp.
+      }
+    }
+    WHERE {
+      {
+        SELECT ?administrativeUnit (MAX(?timestamp) as ?newTimestamp)
+        {
+          GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
+            ?stream <https://w3id.org/tree#member> ?versionedMember .
+            ?versionedMember ext:relatedTo ?administrativeUnit.
+            ?versionedMember ${sparqlEscapeUri(TIME_PREDICATE)} ?timestamp.
+          }
+        }
+        GROUP BY ?administrativeUnit
+      }
+      OPTIONAL {
+        GRAPH <http://mu.semte.ch/graphs/lmb-data-public> {
+          ?administrativeUnit ext:lastLMBUpdate ?oldTimestamp.
+        }
+      }
     }
   `
   await updateSudo(query, {}, options);


### PR DESCRIPTION
### Overview
This PR adjusts the `config/ldes-client/processPage.ts` file to store/update the 'last-update' timestamp for each administrative unit.
The timestamp is stored using an internal `ext:lastLMBUpdate` predicate defined on 'bestuurseenheid' resources.
We can query this timestamp in the frontend to check if an IV is up-to-date.

##### connected issues and PRs:
[GN-5124](https://binnenland.atlassian.net/browse/GN-5124?atlOrigin=eyJpIjoiODRiNGU4ZmVlZjI5NDgyN2FhODdmZmY2ZGQ0YzhkOWEiLCJwIjoiaiJ9)

### Setup
Ensure the ldes-client is correctly set up.
You should test this PR with `BYPASS_MU_AUTH` set to both `true` and `false`.

### How to test/reproduce
- Start virtuoso + database
- Start the ldes-client
- Ensure the consumer consumes the members correctly
- Query the DB to ensure that the `ext:lastLMBUpdate` predicate are stored correctly
- Ensure there is only one `ext:lastLMBUpdate` for each 'bestuurseenheid'
- When making a change in LMB, ensure:
  * It correctly flows through
  * The timestamp for the relevant 'bestuurseenheid' is updated

### Challenges/uncertainties
This adjustment is now needed as we query from our backend directly; and no longer from the LMB SPARQL endpoint.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
