### PR TITLE
Cleanup: remove ununused `vendor-proxy` service

### DIFF
--- a/.changeset/sour-hornets-report.md
+++ b/.changeset/sour-hornets-report.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Remove ununused `vendor-proxy` service

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -340,18 +340,6 @@ defmodule Dispatcher do
   match "/agendapoint-service/*path" do
     forward conn, path, "http://agendapoint-service/"
   end
-
-  options "/vendor-proxy/*path", _ do
-    conn
-    |> Plug.Conn.put_resp_header( "access-control-allow-headers", "content-type,accept" )
-    |> Plug.Conn.put_resp_header( "access-control-allow-methods", "*" )
-    |> send_resp( 200, "{ \"message\": \"ok\" }" )
-  end
-
-  match "/vendor-proxy/*path" do
-    forward conn, path, "http://vendor-proxy/"
-  end
-  
   
 
   #########

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -74,8 +74,6 @@ services:
     restart: "no"
   dashboard-login:
     restart: "no"
-  vendor-proxy:
-    restart: "no"
   lpdc-service:
     restart: "no"
   ldes-client:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,14 +214,6 @@ services:
     logging: *default-logging
     labels:
       - "logging=true"
-  vendor-proxy:
-    image: lblod/vendor-proxy-service:0.1.0
-    environment:
-      QUERY_BASE_URL: 'https://mandatenbeheer.lblod.info'
-      VENDOR_KEY: 'secret'
-      VENDOR_URI: 'http://data.lblod.info/vendors/75ad4503-1699-4e43-8cab-a494142ae571'
-      AUTH_GROUP: 'org'
-    restart: always
   lpdc-service:
     image: lblod/api-proxy-service:1.0.1
     links:


### PR DESCRIPTION
### Overview
As we are no longer using the `vendor-proxy` service as of https://github.com/lblod/frontend-gelinkt-notuleren/pull/742, it doesn't seem really necessary to keep it configured in the stack.

##### connected issues and PRs:
[GN-5124](https://binnenland.atlassian.net/browse/GN-5124)

### Setup
To be used in combination with https://github.com/lblod/frontend-gelinkt-notuleren/pull/742

### How to test/reproduce
Everything should just work as before.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
