### PR TITLE
ldes-client: move `FIRST_PAGE` and `LDES_BASE` env vars to override.example file

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -36,6 +36,8 @@
   #   command: !reset null
   #   environment:
   #     EXTRA_HEADERS: "{\"Authorization\": \"Basic blablablatokengoeshere==\"}"
+  #     FIRST_PAGE: "https:/dev.mandatenbeheer.lblod.info/streams/ldes/abb/1"
+  #     LDES_BASE: "https:/dev.mandatenbeheer.lblod.info/streams/ldes/abb/"
   #     # For the initial ingest, bypass mu auth. remove this after it's
   #     # finished and restart the stack
   #     # BYPASS_MU_AUTH: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -247,8 +247,6 @@ services:
       BATCH_SIZE: 100
       BYPASS_MU_AUTH: "false"
       EXTRA_HEADERS: "secret"
-      FIRST_PAGE: "https:/dev.mandatenbeheer.lblod.info/streams/ldes/abb/1"
-      LDES_BASE: "https:/dev.mandatenbeheer.lblod.info/streams/ldes/abb/"
     labels:
       - "logging=true"
   sparql-cache:


### PR DESCRIPTION
### Overview
This PR simply moves the `FIRST_PAGE` and `LDES_BASE` env vars to override.example file, as they are not really relevant in the main compose file.
