### PR TITLE
Handle tombstone resources for deletions in LDES feed

### DIFF
--- a/.changeset/ten-pots-provide.md
+++ b/.changeset/ten-pots-provide.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Handle Tombstone markers in the ldes feed correctly

--- a/config/ldes-client/processPage.ts
+++ b/config/ldes-client/processPage.ts
@@ -31,7 +31,6 @@ async function replaceExistingData() {
     }
     INSERT {
       GRAPH ?target_graph {
-          ?s a ?type.
           ?s ?pNew ?oNew.
       }
     }
@@ -41,14 +40,14 @@ async function replaceExistingData() {
         ?versionedMember ${sparqlEscapeUri(VERSION_PREDICATE)} ?s .
 
         {
-          ?versionedMember a ?type.
-          VALUES ?type { mandaat:Mandataris mandaat:Fractie org:Membership as:Tombstone }
+          ?versionedMember (a | as:formerType) ?type.
+          VALUES ?type { mandaat:Mandataris mandaat:Fractie org:Membership }
           ?versionedMember ?pNew ?oNew.
           BIND(<http://mu.semte.ch/graphs/lmb-data-public> as ?target_graph)
         }
         UNION
         {
-          ?versionedMember a ?type.
+          ?versionedMember (a | as:formerType) ?type.
           VALUES ?type { person:Person }
           ?versionedMember ?pNew ?oNew.
           VALUES ?pNew {
@@ -61,7 +60,7 @@ async function replaceExistingData() {
         }
         UNION
         {
-          ?versionedMember a ?type.
+          ?versionedMember (a | as:formerType) ?type.
           VALUES ?type { person:Person persoon:Geboorte }
           ?versionedMember ?pNew ?oNew.
           FILTER (?pNew NOT IN ( adms:identifier ))

--- a/config/ldes-client/processPage.ts
+++ b/config/ldes-client/processPage.ts
@@ -22,7 +22,8 @@ async function replaceExistingData() {
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
     PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-    PREFIX adms: <http://www.w3.org/ns/adms#>
+    PREFIX adms: <http://www.w3.org/ns/adms#> 
+    PREFIX as: <http://www.w3.org/ns/activitystreams#>
     DELETE {
       GRAPH ?target_graph {
           ?s ?pOld ?oOld.
@@ -41,7 +42,7 @@ async function replaceExistingData() {
 
         {
           ?versionedMember a ?type.
-          VALUES ?type { mandaat:Mandataris mandaat:Fractie org:Membership }
+          VALUES ?type { mandaat:Mandataris mandaat:Fractie org:Membership as:Tombstone }
           ?versionedMember ?pNew ?oNew.
           BIND(<http://mu.semte.ch/graphs/lmb-data-public> as ?target_graph)
         }
@@ -112,3 +113,4 @@ export async function processPage(){
   await replaceExistingData();
   return;
 }
+


### PR DESCRIPTION
- **fix(ldes): handle Tombstone types**
- **fix(ldes): cleaner method of selecting tombstones**

### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->
the LDES feed uses the [Tombstone](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-tombstone) type to indicate deleted items.
It swaps out the subject's type for Tombstone, and adds the old type under the
`formerType` predicate. It's a clean mechanism, we just have to make sure to
capture the tombstone types to overwrite the old data.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

this will of course only work on new ldes data, so you have to reset your ldes
state for it to pick up on all the deletions

here's how to reset your ldes state without nuking your db:
```sparql
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
DELETE {
  GRAPH ?g {
    ?s ?p ?v.
  }
} WHERE { 
  GRAPH ?g { 
    ?s a ext:LDESClientState; 
        ?p ?v. 
  } 
}
```
this will cause the client to do a full ingest on the next tick, so make sure your `BYPASS_MU_AUTH` is set accordingly

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] changelog
- [x] no new deprecations
