### PR TITLE
Link relevant `bestuursperiode` resources to eachother

### DIFF
--- a/config/migrations/2024/2024-11/20241104144651-link-bestuursperiodes-to-eachother.sparql
+++ b/config/migrations/2024/2024-11/20241104144651-link-bestuursperiodes-to-eachother.sparql
@@ -1,0 +1,10 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7>
+        ext:previous <http://data.lblod.info/id/concept/Bestuursperiode/a2b977a3-ce68-4e42-80a6-4397f66fc5ca>.
+    <http://data.lblod.info/id/concept/Bestuursperiode/a2b977a3-ce68-4e42-80a6-4397f66fc5ca>
+        ext:previous <http://data.lblod.info/id/concept/Bestuursperiode/845dbc7f-139e-4632-b200-f90e180f1dba>
+  }
+}

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -773,6 +773,11 @@
   :properties `((:start-year :number ,(s-prefix "lmb:startYear"))
                 (:end-year :number ,(s-prefix "lmb:endYear"))
                 (:label :string ,(s-prefix "skos:prefLabel")))
+  :has-one `((bestuursperiode :via ,(s-prefix "ext:previous") 
+                              :as "previous")
+             (bestuursperiode :via ,(s-prefix "ext:previous")
+                              :inverse t
+                              :as "next"))
   :resource-base (s-url "http://data.lblod.info/id/concept/Bestuursperiode/")
   :features '(include-uri)
   :on-path "bestuursperiodes"


### PR DESCRIPTION
### Overview
This PR adds a migration which links the relevant bestuursperiodes to each other using the `ext:previous` relationship.
Additionally, it also adds this relationships (and it's inverse) to the resources config.

##### connected issues and PRs:
Needed for https://binnenland.atlassian.net/browse/GN-5181 to be able to easily fetch information on the previous legislation.


### Setup
None

### How to test/reproduce
- Start the `virtuoso` and `migrations` services + ensure all migrations have run
- Start the rest of the stack
- Ensure that, when fetching `/bestuursorganen`, the correct `previous` and `next` relationships are included.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] no new deprecations
