### PR TITLE
fix(ldes-client): ensure type of person is correctly consumed

### DIFF
--- a/.changeset/cuddly-poets-greet.md
+++ b/.changeset/cuddly-poets-greet.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+adjustment to ldes-client configuration: ensure the type of a person `http://www.w3.org/ns/person#Person` is correctly consumed into the public graph

--- a/config/ldes-client/processPage.ts
+++ b/config/ldes-client/processPage.ts
@@ -51,6 +51,8 @@ async function replaceExistingData() {
           VALUES ?type { person:Person }
           ?versionedMember ?pNew ?oNew.
           VALUES ?pNew {
+              rdf:type
+              as:formerType
               dct:modified
               mu:uuid
               foaf:familyName


### PR DESCRIPTION
### Overview
This PR ensures that the type of a person resource (http://www.w3.org/ns/person#Person) is also correctly consumed and inserted into the public graph.


##### connected issues and PRs:
Discovered while working on [GN-5217](https://binnenland.atlassian.net/browse/GN-5217)

### Setup
- Ensure you have the ldes-client setup correctly.
- Set `EMBER_GN_FEATURE_MANDATEE_TABLE_EDITOR` to `true` to easily test/add mandatee tables.

### How to test/reproduce
- Start the stack, ensure the `ldes-client` service has finished consuming
- Open the frontend, and login as an OCMW
- Logging in with the corresponding user in LMB, add a 'non-elected'/custom person to the BCSD council
- The `ldes-client` should consume the new person and mandatee
   * The public information should be consumed into the public graph
   * The private info into a private graph (note: it will be consumed into the private graph of the municipality, not the OCMW, this seems to be an error/issue on the side of LMB, but is not actually an issue for us as we only need their public data)
- When syncing the IV containing a mandatee table (e.g. `IVRMW2-LMB-2-kandidaat-leden`), the custom person should show up.

### Challenges/uncertainties
- The missing types also need to be added on QA, DEV, Prod...
  * Through 1+ migrations (depending on the amount of results)
  * Through a direct query
  * Through resetting the ldes-feed
- Maybe we should rereview all the data pushed on the ldes-feed and adapt the query to consume an exhaustive list of predicates/data we need.
  * https://github.com/lblod/app-lokaal-mandatenbeheer/blob/35f6a7976bf9d97d72f4fcbd117e06df531daa31/config/ldes-delta-pusher/ldes-instances.ts#L224-L290 contains an exhaustive list of all published official predicates



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
