### PR TITLE
Grant file creation/write permission to accounts with 'Publiceerder' and 'Ondertekenaar' roles

### DIFF
--- a/.changeset/fluffy-kings-help.md
+++ b/.changeset/fluffy-kings-help.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Ensure accounts with the `GelinktNotuleren-publiceerder` and `GelinktNotuleren-ondertekenaar` roles are allowed to create files.

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -192,6 +192,7 @@ defmodule Acl.UserGroups.Config do
                     graph: "http://mu.semte.ch/graphs/organizations/",
                     constraint: %ResourceConstraint{
                       resource_types: [
+                        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
                         "http://data.vlaanderen.be/ns/besluitvorming#Agenda",
                         "http://mu.semte.ch/vocabularies/ext/VersionedAgenda",
                         "http://mu.semte.ch/vocabularies/ext/VersionedNotulen",
@@ -221,6 +222,7 @@ defmodule Acl.UserGroups.Config do
                     graph: "http://mu.semte.ch/graphs/organizations/",
                     constraint: %ResourceConstraint{
                       resource_types: [
+                        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
                         "http://data.vlaanderen.be/ns/besluitvorming#Agenda",
                         "http://mu.semte.ch/vocabularies/ext/VersionedAgenda",
                         "http://mu.semte.ch/vocabularies/ext/VersionedNotulen",


### PR DESCRIPTION
### Overview
This ensures that the following roles have the possibility to create/write `http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject` objects:
- GelinktNotuleren-publiceerder
- GelinktNotuleren-ondertekenaar

This ensures that accounts with these roles, but without the 'Schrijver' role, have the option to sign and publish notulen.

### How to test/reproduce
- Start the app
- Login as a 'Lezer' account
- Open a meeting for which the 'notulen' have not been signed yet
- Ensure you can add a first signature successfully
- Ensure you can publish the notulen successfully

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
