### PR TITLE
Add migration to delete extra aangebrachtNa for Linkebeek

### DIFF
--- a/.changeset/yellow-moles-give.md
+++ b/.changeset/yellow-moles-give.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Add migration to fix a signing issue seen by Linkebeek

--- a/config/migrations/2024/2024-11/20241127135154-fix-linkebeek-meeting.sparql
+++ b/config/migrations/2024/2024-11/20241127135154-fix-linkebeek-meeting.sparql
@@ -1,0 +1,12 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+DELETE {
+  GRAPH ?g {
+    ?agendapoint besluit:aangebrachtNa <http://data.lblod.info/id/agendapunten/6735E0D5E7AA49C45553C1CC> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?agendapoint besluit:aangebrachtNa <http://data.lblod.info/id/agendapunten/6735E0D5E7AA49C45553C1CC> .
+  }
+}


### PR DESCRIPTION
### Overview
Allows the prepublisher to handle the meeting.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5285

### Setup
Run on a prod backup

### How to test/reproduce
- go to Gemeente Linkebeek, meeting College van Burgemeester en schepenen, 19/11/2024
- Sign and publish the meeting

### Challenges/uncertainties
The documents are weird since the headings do not appear correctly in the editor, but since the RDFa is correct, they seem to be handled correctly by the prepublisher.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [ ] no new deprecations
