### PR TITLE
add daily iv report

### DIFF
--- a/.changeset/bright-clocks-cry.md
+++ b/.changeset/bright-clocks-cry.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Add daily IV report

--- a/config/reports/historicalReport.js
+++ b/config/reports/historicalReport.js
@@ -3,17 +3,17 @@ import { MONTHS } from "./utils/constants";
 import { getLastMonth, getMonthDates } from "./utils/date";
 
 export default {
-	name: "historicalReport",
-	execute: async () => {
-		const start = new Date(1970, 0, 1);
-		const { month, year } = getLastMonth();
+  name: "historicalReport",
+  execute: async () => {
+    const start = new Date(1970, 0, 1);
+    const { month, year } = getLastMonth();
     const end = getMonthDates(month, year).end;
-		const metadata = {
-			title: `Historische statistieken t.e.m. ${MONTHS[month]} ${year}`,
-			description:
-				"Historische statistieken over het aantal aangemaakte, ondertekende en gepubliceerde documenten",
-			filePrefix: `historische-statistieken`,
-		};
-		await generateReport(start, end, metadata);
-	},
+    const metadata = {
+      title: `Historische statistieken t.e.m. ${MONTHS[month]} ${year}`,
+      description:
+        "Historische statistieken over het aantal aangemaakte, ondertekende en gepubliceerde documenten",
+      filePrefix: `historische-statistieken`,
+    };
+    await generateReport(start, end, metadata);
+  },
 };

--- a/config/reports/index.js
+++ b/config/reports/index.js
@@ -1,4 +1,5 @@
 import historicalReport from "./historicalReport";
 import monthlyReport from "./monthlyReport";
+import ivReport from "./ivReport";
 
-export default [monthlyReport, historicalReport];
+export default [monthlyReport, historicalReport, ivReport];

--- a/config/reports/ivReport.js
+++ b/config/reports/ivReport.js
@@ -1,0 +1,71 @@
+import generateReport from "./reportGenerator.js";
+import { MONTHS } from "./utils/constants.js";
+import { getToday } from "./utils/date.js";
+import { generateReportFromData } from "../helpers.js";
+import { querySudo as query } from "@lblod/mu-auth-sudo";
+
+export default {
+  cronPattern: "0 0 0 * * *",
+  name: "ivReport",
+  execute: async () => {
+    const { day, month, year } = getToday();
+    const metadata = {
+      title: `IV Statistieken ${day} ${MONTHS[month]} ${year}`,
+      description:
+        "Maandelijkse statistieken over het installatie vergadering gesynchroniseerd en niet",
+      filePrefix: `iv-statistieken-${day}-${month + 1}-${year}`,
+    };
+    await generateIvReport(metadata);
+  },
+};
+
+async function generateIvReport(metadata) {
+  const queryString = `
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    SELECT ?adminUnitName (COUNT(DISTINCT ?ivMeeting) as ?installatieVergaderingCount) (COUNT(DISTINCT ?ivMeetingSync) as ?installatieVergaderingSyncedCount)  WHERE {
+        OPTIONAL {
+            ?ivMeeting a ext:Installatievergadering;
+                besluit:isGehoudenDoor ?adminUnit.
+        }
+        ?adminUnit mandaat:isTijdspecialisatieVan ?adminUnitSpecialised.
+        ?adminUnitSpecialised skos:prefLabel ?adminUnitName.
+        OPTIONAL {
+            ?ivMeetingSync a ext:Installatievergadering;
+                ext:synchronizationStatus ?syncStatus;
+                besluit:isGehoudenDoor ?adminUnit.
+        }
+    } 
+  `;
+
+  const queryResponse = await query(queryString);
+  const data = queryResponse.results.bindings.map((entry) => {
+    return {
+      adminUnitName: getValue(entry, "adminUnitName"),
+      installatieVergaderingCount: getValue(
+        entry,
+        "installatieVergaderingCount"
+      ),
+      installatieVergaderingSyncedCount: getValue(
+        entry,
+        "installatieVergaderingSyncedCount"
+      ),
+    };
+  });
+
+  await generateReportFromData(
+    data,
+    [
+      "adminUnitName",
+      "installatieVergaderingCount",
+      "installatieVergaderingSyncedCount",
+    ],
+    metadata
+  );
+}
+
+function getValue(entry, property, defaultValue = 0) {
+  return entry[property] ? entry[property].value : defaultValue;
+}

--- a/config/reports/ivReport.js
+++ b/config/reports/ivReport.js
@@ -25,18 +25,14 @@ async function generateIvReport(metadata) {
     PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-    SELECT ?adminUnitName (COUNT(DISTINCT ?ivMeeting) as ?installatieVergaderingCount) (COUNT(DISTINCT ?ivMeetingSync) as ?installatieVergaderingSyncedCount)  WHERE {
-        OPTIONAL {
-            ?ivMeeting a ext:Installatievergadering;
-                besluit:isGehoudenDoor ?adminUnit.
-        }
-        ?adminUnit mandaat:isTijdspecialisatieVan ?adminUnitSpecialised.
-        ?adminUnitSpecialised skos:prefLabel ?adminUnitName.
-        OPTIONAL {
-            ?ivMeetingSync a ext:Installatievergadering;
-                ext:synchronizationStatus ?syncStatus;
-                besluit:isGehoudenDoor ?adminUnit.
-        }
+    SELECT ?adminUnitName (COUNT(DISTINCT ?ivMeeting) as ?installatieVergaderingCount) (COUNT(DISTINCT ?syncStatus) as ?installatieVergaderingSyncedCount)  WHERE {
+      ?ivMeeting a ext:Installatievergadering;
+        besluit:isGehoudenDoor ?adminUnit.
+      ?adminUnit mandaat:isTijdspecialisatieVan ?adminUnitSpecialised.
+      ?adminUnitSpecialised skos:prefLabel ?adminUnitName.
+      OPTIONAL {
+          ?ivMeeting ext:synchronizationStatus ?syncStatus.
+      }
     } 
   `;
 

--- a/config/reports/ivReport.js
+++ b/config/reports/ivReport.js
@@ -12,7 +12,7 @@ export default {
     const metadata = {
       title: `IV Statistieken ${day} ${MONTHS[month]} ${year}`,
       description:
-        "Maandelijkse statistieken over het installatie vergadering gesynchroniseerd en niet",
+        "Dagelijkse statistieken over het aantal creaties en synchronisaties van installatievergaderingen per bestuursorgaan",
       filePrefix: `iv-statistieken-${day}-${month + 1}-${year}`,
     };
     await generateIvReport(metadata);

--- a/config/reports/monthlyReport.js
+++ b/config/reports/monthlyReport.js
@@ -3,17 +3,17 @@ import { MONTHS } from "./utils/constants.js";
 import { getLastMonth, getMonthDates } from "./utils/date.js";
 
 export default {
-	cronPattern: "0 0 12 1 * *",
-	name: "monthlyReport",
-	execute: async () => {
-		const { month, year } = getLastMonth();
-		const { start, end } = getMonthDates(month, year);
-		const metadata = {
-			title: `Statistieken ${MONTHS[month]} ${year}`,
-			description:
-				"Maandelijkse statistieken over het aantal aangemaakte, ondertekende en gepubliceerde documenten",
-			filePrefix: `statistieken-${month + 1}-${year}`,
-		};
-		await generateReport(start, end, metadata);
-	},
+  cronPattern: "0 0 12 1 * *",
+  name: "monthlyReport",
+  execute: async () => {
+    const { month, year } = getLastMonth();
+    const { start, end } = getMonthDates(month, year);
+    const metadata = {
+      title: `Statistieken ${MONTHS[month]} ${year}`,
+      description:
+        "Maandelijkse statistieken over het aantal aangemaakte, ondertekende en gepubliceerde documenten",
+      filePrefix: `statistieken-${month + 1}-${year}`,
+    };
+    await generateReport(start, end, metadata);
+  },
 };

--- a/config/reports/utils/date.js
+++ b/config/reports/utils/date.js
@@ -1,6 +1,5 @@
 export function getLastMonth() {
   const date = new Date();
-  console.log(date.toISOString());
   date.setDate(1);
   date.setMonth(date.getMonth() - 1);
   return { month: date.getMonth(), year: date.getFullYear() };

--- a/config/reports/utils/date.js
+++ b/config/reports/utils/date.js
@@ -1,13 +1,23 @@
 export function getLastMonth() {
-	const date = new Date();
-	console.log(date.toISOString())
-	date.setDate(1);
-	date.setMonth(date.getMonth() - 1);
-	return { month: date.getMonth(), year: date.getFullYear() };
+  const date = new Date();
+  console.log(date.toISOString());
+  date.setDate(1);
+  date.setMonth(date.getMonth() - 1);
+  return { month: date.getMonth(), year: date.getFullYear() };
 }
 
 export function getMonthDates(month, year) {
-	const start = new Date(year, month, 1);
-	const end = new Date(year, month + 1, 0);
-	return { start, end };
+  const start = new Date(year, month, 1);
+  const end = new Date(year, month + 1, 0);
+  return { start, end };
+}
+
+export function getToday() {
+  const date = new Date();
+
+  return {
+    day: date.getDate(),
+    month: date.getMonth(),
+    year: date.getFullYear(),
+  };
 }


### PR DESCRIPTION
### Overview
Made a report about the number of IV created in each admin unit, and the number of those IVs that were synced

##### connected issues and PRs:
GN-5197


### Setup
You will need a user to login into the dashboard

### How to test/reproduce
reduce the cron on the ivReport file to make it run soon, verify that the cron is run and that the report generated is correct

### Challenges/uncertainties
Waiting for a better translation for the report description and asked Arne if I should check if the synchronization was successful or not



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
