### PR TITLE
feat(ldes-client): adjust tombstone handling

### DIFF
--- a/.changeset/late-donkeys-travel.md
+++ b/.changeset/late-donkeys-travel.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Add migration which drops all data related to tombstones from our database

--- a/.changeset/tasty-cycles-accept.md
+++ b/.changeset/tasty-cycles-accept.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Adjust ldes-client `processPage` logic to remove incoming tombstones entirely

--- a/config/ldes-client/processPage.ts
+++ b/config/ldes-client/processPage.ts
@@ -40,19 +40,18 @@ async function replaceExistingData() {
         ?versionedMember ${sparqlEscapeUri(VERSION_PREDICATE)} ?s .
 
         {
-          ?versionedMember (a | as:formerType) ?type.
+          ?versionedMember a ?type.
           VALUES ?type { mandaat:Mandataris mandaat:Fractie org:Membership }
           ?versionedMember ?pNew ?oNew.
           BIND(<http://mu.semte.ch/graphs/lmb-data-public> as ?target_graph)
         }
         UNION
         {
-          ?versionedMember (a | as:formerType) ?type.
+          ?versionedMember a ?type.
           VALUES ?type { person:Person }
           ?versionedMember ?pNew ?oNew.
           VALUES ?pNew {
               rdf:type
-              as:formerType
               dct:modified
               mu:uuid
               foaf:familyName
@@ -62,7 +61,7 @@ async function replaceExistingData() {
         }
         UNION
         {
-          ?versionedMember (a | as:formerType) ?type.
+          ?versionedMember a ?type.
           VALUES ?type { person:Person persoon:Geboorte }
           ?versionedMember ?pNew ?oNew.
           FILTER (?pNew NOT IN ( adms:identifier ))
@@ -76,6 +75,29 @@ async function replaceExistingData() {
           ?s ?pOld ?oOld.
         }
       }
+    };
+    DELETE {
+      GRAPH ?g {
+        ?member ?pOut ?oOut.
+        ?sIn ?pIn ?member.
+      }
+    }
+    WHERE {
+      GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
+        ?stream <https://w3id.org/tree#member> ?versionedMember .
+        ?versionedMember ${sparqlEscapeUri(VERSION_PREDICATE)} ?member .
+        ?versionedMember a as:Tombstone.
+      }
+      GRAPH ?g {
+        {
+          ?member ?pOut ?oOut.
+        }
+        UNION
+        {
+          ?sIn ?pIn ?member.
+        }
+      }
+      FILTER(?g != ${sparqlEscapeUri(BATCH_GRAPH)})
     };
     DELETE {
       GRAPH <http://mu.semte.ch/graphs/lmb-data-public> {

--- a/config/migrations/20241129121508-clean-up-tombstones.sparql
+++ b/config/migrations/20241129121508-clean-up-tombstones.sparql
@@ -1,0 +1,21 @@
+PREFIX as: <http://www.w3.org/ns/activitystreams#>
+
+DELETE {
+  GRAPH ?g {
+    ?tombstone a as:Tombstone.
+    ?tombstone ?p_out ?o_out.
+    ?s_in ?p_in ?tombstone.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?tombstone a as:Tombstone.
+    {
+      ?tombstone ?p_out ?o_out.
+    }
+    UNION
+    {
+      ?s_in ?p_in ?tombstone.
+    }
+  }
+}


### PR DESCRIPTION
### Overview
This PR includes some modifications in how we handle tombstone (deleted) resources in the lmb ldes-client.
Specifically this PR includes:
- A migration which removes all outgoing and incoming triples related to tombstone resources, across all graphs
- An adjustment to `processPage.ts` to remove incoming tombstones resources completely from our database (all related triples)


##### connected issues and PRs:
None

### Setup
Ensure you have the `ldes-client` service set-up locally

### How to test/reproduce
**Scenario 1: starting from an empty database**
- Start virtuoso + migrations from scratch
- Connect the `ldes-client` to your LMB environment of choice
- Start the `ldes-client` and let it run (to completion)
- Ensure that the triplestore does not contain any tombstone resources

**Scenario 2: starting from a DEV/QA/PROD backup**
- Run the migration and ensure all tombstone resources (+ connected triples) are removed
- The ldes-client should work as expected

### Challenges/uncertainties
- I used `UNION` instead of `OPTIONAL` as it is more performant
- The migration needs a high `ResultSetMaxRows` to fully execute

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
