### PR TITLE
GN-5245: modernize standard templates

### DIFF
--- a/.changeset/bright-oranges-lie.md
+++ b/.changeset/bright-oranges-lie.md
@@ -1,0 +1,7 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Addition of migrations which update the built-in standard templates:
+- Addition of dutch labels to RDFa blocks
+- Modernize usage of template URIs

--- a/.changeset/hip-cooks-jam.md
+++ b/.changeset/hip-cooks-jam.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Update frontend to version [5.46.0](https://github.com/lblod/frontend-gelinkt-notuleren/releases/tag/v5.46.0)

--- a/config/migrations/20241206125700-modernize-template-minimaal-besluit.sparql
+++ b/config/migrations/20241206125700-modernize-template-minimaal-besluit.sparql
@@ -1,0 +1,34 @@
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/b04fc03e-e8ff-496a-9343-1f07b4f55551> <http://mu.semte.ch/vocabularies/ext/templateContent> ?templateContent
+  }
+};
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/b04fc03e-e8ff-496a-9343-1f07b4f55551> <http://mu.semte.ch/vocabularies/ext/templateContent> 
+    """
+    <div
+      property="prov:generated"
+      resource="http://data.lblod.info/id/besluiten/--ref-uuid4-a03ac0ee-b301-42ef-bcfd-1db56cbf7a0a"
+      typeof="besluit:Besluit ext:BesluitNieuweStijl"
+      data-label="Besluit"
+    >
+      <div style="display: none" data-rdfa-container="true">
+        <span
+          property="eli:language"
+          resource="http://publications.europa.eu/resource/authority/language/NLD"
+        />
+      </div>
+      <div data-content-container="true">
+        <div property="eli:title" datatype="xsd:string" data-label="Openbare titel besluit">
+          <h4><span class="mark-highlight-manual">Geef titel besluit op</span></h4>
+        </div>
+        <br />
+        <div property="eli:description" datatype="xsd:string" data-label="Korte openbare beschrijving">
+          <p><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
+        </div>
+      </div>
+    </div>
+    """.
+  }
+}

--- a/config/migrations/20241206125712-modernize-template-nieuw-besluit.sparql
+++ b/config/migrations/20241206125712-modernize-template-nieuw-besluit.sparql
@@ -1,0 +1,75 @@
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/6933312e-2bac-11e9-af69-3baeff70b1a8> <http://mu.semte.ch/vocabularies/ext/templateContent> ?templateContent
+  }
+};
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/6933312e-2bac-11e9-af69-3baeff70b1a8> <http://mu.semte.ch/vocabularies/ext/templateContent> 
+    """
+    <div
+      property="prov:generated"
+      resource="http://data.lblod.info/id/besluiten/--ref-uuid4-c10209c0-dfba-46fb-80c7-1c6aedf656e9"
+      typeof="besluit:Besluit ext:BesluitNieuweStijl"
+      data-label="Besluit"
+    >
+      <div style="display: none" data-rdfa-container="true">
+        <span
+          property="eli:language"
+          resource="http://publications.europa.eu/resource/authority/language/NLD"
+        />
+      </div>
+      <div data-content-container="true">
+        <div
+          property="eli:title"
+          datatype="xsd:string"
+          data-label="Openbare titel besluit"
+        >
+          <h4><span class="mark-highlight-manual">Geef titel besluit op</span></h4>
+        </div>
+        <div
+          property="eli:description"
+          datatype="xsd:string"
+          data-label="Korte openbare beschrijving"
+        >
+          <p><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
+        </div>
+        <div property="besluit:motivering" lang="nl" data-label="Motivering">
+          <p><span class="mark-highlight-manual">geef bestuursorgaan op</span>,</p>
+          <br />
+          <h5>Bevoegdheid</h5>
+          <ul class="bullet-list">
+            <li><span class="mark-highlight-manual">Rechtsgrond die bepaalt dat dit orgaan bevoegd is.</span></li>
+          </ul>
+          <br />
+          <h5>Juridische context</h5>
+          <ul class="bullet-list">
+            <li><span class="mark-highlight-manual">Voeg juridische context in</span></li>
+          </ul>
+          <br />
+          <h5>Feitelijke context en argumentatie</h5>
+          <ul class="bullet-list">
+            <li><span class="mark-highlight-manual">Voeg context en argumentatie in</span></li>
+          </ul>
+        </div>
+        <br />
+        <br />
+        <h5>Beslissing</h5>
+        <div property="prov:value" datatype="xsd:string" data-label="Artikels">
+          <div
+            property="eli:has_part"
+            resource="http://data.lblod.info/artikels/--ref-uuid4-7a0552ff-4fb1-4e42-98d6-dd88faf60f0c"
+            typeof="besluit:Artikel"
+            data-say-is-only-article="true"
+          >
+            <div>Artikel <span property="eli:number" datatype="xsd:string">1</span></div>
+            <div property="prov:value" datatype="xsd:string">
+              <span class="mark-highlight-manual">Voer inhoud in</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """.
+  }
+}

--- a/config/migrations/20241206125717-modernize-template-reglement.sparql
+++ b/config/migrations/20241206125717-modernize-template-reglement.sparql
@@ -1,0 +1,80 @@
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/2deed136-94c2-47ec-a542-8746cd020579> <http://mu.semte.ch/vocabularies/ext/templateContent> ?templateContent
+  }
+};
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/2deed136-94c2-47ec-a542-8746cd020579> <http://mu.semte.ch/vocabularies/ext/templateContent> 
+    """
+    <div
+      property="prov:generated"
+      resource="http://data.lblod.info/id/besluiten/--ref-uuid4-c10209c0-dfba-46fb-80c7-1c6aedf656e9"
+      typeof="besluit:Besluit https://data.vlaanderen.be/id/concept/BesluitType/67378dd0-5413-474b-8996-d992ef81637a ext:BesluitNieuweStijl"
+      data-label="Besluit"
+    >
+      <div style="display: none" data-rdfa-container="true">
+        <span
+          property="eli:language"
+          resource="http://publications.europa.eu/resource/authority/language/NLD"
+        />
+      </div>
+      <div data-content-container="true">
+        <div property="eli:title" datatype="xsd:string" data-label="Openbare titel besluit">
+          <h4><span class="mark-highlight-manual">Geef titel besluit op</span></h4>
+        </div>
+        <div property="eli:description" datatype="xsd:string" data-label="Korte openbare beschrijving">
+          <p><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
+        </div>
+        <br />
+        <div property="besluit:motivering" lang="nl" data-label="Motivering">
+          <p><span class="mark-highlight-manual">geef bestuursorgaan op</span>, </p>
+        <br> 
+        <h5>Bevoegdheid</h5> 
+        <ul class="bullet-list"> 
+          <li><span class="mark-highlight-manual">Rechtsgrond die bepaalt dat dit orgaan bevoegd is.</span></li> 
+        </ul> 
+        <br> 
+        <h5>Juridische context</h5>
+        <ul class="bullet-list"> 
+          <li><a class="annotation" property="eli:cites" typeof="eli:LegalExpression" href="https://codex.vlaanderen.be/doc/document/1009730">Nieuwe gemeentewet</a>&nbsp;(KB 24/06/1988)</li> 
+          <li>decreet <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1029017" property="eli:cites" typeof="eli:LegalExpression">over het lokaal bestuur</a> van 22/12/2017</li> 
+          <li>wet <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1009628" property="eli:cites" typeof="eli:LegalExpression">betreffende de politie over het wegverkeer (wegverkeerswet - Wet van 16 maart 1968)</a></li> 
+          <li>wegcode - Koninklijk Besluit <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1036242" property="eli:cites" typeof="eli:LegalExpression">van 1 december 1975 houdende algemeen reglement op de politie van het wegverkeer en van het gebruik van de openbare weg.</a></li> 
+          <li>code van de wegbeheerder - <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1035575" property="eli:cites" typeof="eli:LegalExpression">ministerieel besluit van 11 oktober 1976 houdende de minimumafmetingen en de bijzondere plaatsingsvoorwaarden van de verkeerstekens</a></li> 
+        </ul> 
+        <br> 
+        <em>specifiek voor aanvullende reglementen op het wegverkeer (= politieverordeningen m.b.t. het wegverkeer voor wat betreft permanente of periodieke verkeerssituaties)</em> 
+        <ul class="bullet-list"> 
+          <li>decreet <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1016816" property="eli:cites" typeof="eli:LegalExpression">betreffende de aanvullende reglementen op het wegverkeer en de plaatsing en bekostiging van de verkeerstekens </a>(16 mei 2008)</li> 
+          <li>Besluit van de Vlaamse Regering <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1017729" property="eli:cites" typeof="eli:LegalExpression">betreffende de aanvullende reglementen en de plaatsing en bekostiging van verkeerstekens</a>​ van 23 januari 2009</li> 
+          <li><a href="https://codex.vlaanderen.be/doc/document/1035938" property="eli:cites" typeof="eli:LegalExpression">Omzendbrief MOB/2009/01 van 3 april 2009 gemeentelijke aanvullende reglementen op de politie over het wegverkeer</a></li> 
+        </ul> 
+        <h5>Feitelijke context en argumentatie</h5> 
+        <ul class="bullet-list"> 
+          <li><span class="mark-highlight-manual">Voeg context en argumentatie in</span></li> 
+        </ul> 
+        </div>
+        <br />
+        <br />
+        <h5>Beslissing</h5>
+        <div property="prov:value" datatype="xsd:string" data-label="Artikels">
+          <div
+            property="eli:has_part"
+            resource="http://data.lblod.info/artikels/--ref-uuid4-68c56ef4-8843-4b7f-a72a-9d0038ff723f"
+            typeof="besluit:Artikel"
+            data-say-is-only-article="true"
+          >
+            <div>
+              Artikel <span property="eli:number" datatype="xsd:string">1</span>
+            </div>
+            <div property="prov:value" datatype="xsd:string">
+              <span class="mark-highlight-manual">Voer inhoud in</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """.
+  }
+}

--- a/config/migrations/20241206125726-modernize-template-klassiek-besluit.sparql
+++ b/config/migrations/20241206125726-modernize-template-klassiek-besluit.sparql
@@ -1,0 +1,74 @@
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/39c31a7e-2ba9-11e9-88cf-83ebfda837dc> <http://mu.semte.ch/vocabularies/ext/templateContent> ?templateContent
+  }
+};
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/39c31a7e-2ba9-11e9-88cf-83ebfda837dc> <http://mu.semte.ch/vocabularies/ext/templateContent> 
+    """
+    <div
+      property="prov:generated"
+      resource="http://data.lblod.info/id/besluiten/--ref-uuid4-5ab24a9b-4760-4607-81c1-38dd53c13dff"
+      typeof="besluit:Besluit ext:BesluitKlassiekeStijl"
+      data-label="Besluit"
+    >
+      <div style="display: none" data-rdfa-container="true">
+        <span
+          property="eli:language"
+          resource="http://publications.europa.eu/resource/authority/language/NLD"
+        />
+      </div>
+      <div data-content-container="true">
+        <div
+          property="eli:title"
+          datatype="xsd:string"
+          data-label="Openbare titel besluit"
+        >
+          <h5><span class="mark-highlight-manual">Geef titel besluit op</span></h5>
+        </div>
+        <div
+          property="eli:description"
+          datatype="xsd:string"
+          data-label="Korte openbare beschrijving"
+        >
+          <p><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
+        </div>
+        <div property="besluit:motivering" lang="nl" data-label="Motivering">
+          <p><span class="mark-highlight-manual">geef bestuursorgaan op</span>,</p>
+          <br />
+          <div>
+            <ul class="bullet-list">
+              <li>Gelet op <span class="mark-highlight-manual">Voeg juridische grond in</span>;</li>
+            </ul>
+          </div>
+          <br />
+          <div>
+            <ul class="bullet-list">
+              <li>Overwegende dat <span class="mark-highlight-manual">Voeg motivering in</span>;</li>
+            </ul>
+          </div>
+        </div>
+        <br />
+        <br />
+        <p class="u-spacer--small">Beslist,</p>
+        <div property="prov:value" datatype="xsd:string" data-label="Artikels">
+          <div
+            property="eli:has_part"
+            resource="http://data.lblod.info/artikels/--ref-uuid4-69ba01d6-db79-4b36-8ed4-d824269724df"
+            typeof="besluit:Artikel"
+            data-say-is-only-article="true"
+          >
+            <div>
+              Artikel <span property="eli:number" datatype="xsd:string">1</span>
+            </div>
+            <div property="prov:value" datatype="xsd:string">
+              <span class="mark-highlight-manual">Voer inhoud in</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """.
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     labels:
       - "logging=true"
   editor:
-    image: lblod/frontend-gelinkt-notuleren:5.45.0
+    image: lblod/frontend-gelinkt-notuleren:5.46.0
     restart: always
     logging: *default-logging
     labels:


### PR DESCRIPTION
### Overview
This PR includes some migrations with some updates to the built-in standard templates:
- Addition of dutch RDFa block labels
- Modernize template URIs
- Remove weird `inline_rdfa` element

Patch files which showcases the changes made to the templates:
[patch_files.zip](https://github.com/user-attachments/files/18038828/patch_files.zip)


##### connected issues and PRs:
[GN-5245](https://binnenland.atlassian.net/browse/GN-5245)
To be used in combination with https://github.com/lblod/frontend-gelinkt-notuleren/pull/793

### Setup
Check-out https://github.com/lblod/frontend-gelinkt-notuleren/pull/793

### How to test/reproduce
- Start the stack and ensure the migrations have run
- Start the frontend dev server
- Create APs based on each of the following templates
  * Generiek besluit (nieuwe stijl)
  * Generiek besluit (klassieke stijl)
  * Minimaal besluit
  * Aanvullend reglement besluit
- Changes:
   * Each of the created documents should now contain RDFa blocks with dutch labels
   * The template URIs should be correctly instantiated
   * The weird `inline_rdfa` element should no longer be visible
- Add these agendapoints to a meeting. Ensure the meeting correctly takes over the titles + descriptions of the APs

### Challenges/uncertainties
- I moved the `eli:language` property to be inline instead of an `inline_rdfa` node
- This PR is a draft until https://github.com/lblod/frontend-gelinkt-notuleren/pull/793 is merged and released

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
