### PR TITLE
Run ivReport every day, not every minute

### DIFF
--- a/.changeset/tough-berries-breathe.md
+++ b/.changeset/tough-berries-breathe.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Run ivReport every day, not every minute

--- a/config/reports/ivReport.js
+++ b/config/reports/ivReport.js
@@ -5,7 +5,7 @@ import { generateReportFromData } from "../helpers.js";
 import { querySudo as query } from "@lblod/mu-auth-sudo";
 
 export default {
-  cronPattern: "0 * * * * *",
+  cronPattern: "0 0 0 * * *",
   name: "ivReport",
   execute: async () => {
     const { day, month, year } = getToday();


### PR DESCRIPTION
### Overview
I set it to run at midnight, it's unclear if this is correct.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Look at the dashboard locally and see that there are no longer new reports generated every minute.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [ ] no new deprecations
