### PR TITLE
GN-5391: increase CRON interval of ldes-client

### DIFF
--- a/.changeset/fast-queens-live.md
+++ b/.changeset/fast-queens-live.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Increase the CRON interval of the ldes-client service from 5 seconds to 1 minute

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -234,6 +234,7 @@ services:
       - virtuoso:virtuoso
     restart: always
     environment:
+      CRON_PATTERN: "*/1 * * * *"
       TARGET_GRAPH: "http://mu.semte.ch/graphs/mandaten-staging"
       DIRECT_DATABASE_CONNECTION: "http://virtuoso:8890/sparql"
       RANDOMIZE_GRAPHS: "true"


### PR DESCRIPTION
### Overview
This PR increases the CRON interval of the `ldes-client` service from 5 seconds to 1 minute.
This will hopefully mitigate/reduce the amount of transaction deadlocks caused.

##### connected issues and PRs:
[GN-5391](https://binnenland.atlassian.net/browse/GN-5391)

### Setup
Ensure the `ldes-client` service is enabled

### How to test/reproduce
- Start the stack
- Ensure the `ldes-client` service only ingests once every minute instead of every 5 seconds

### Challenges/uncertainties
This is not guaranteed to be a permanent solution to the deadlocks issue, but should decrease the load on virtuoso a lot.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
