### PR TITLE
Add missing logging keys to docker-compose.yml

### DIFF
--- a/.changeset/blue-toes-watch.md
+++ b/.changeset/blue-toes-watch.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": patch
+---
+
+Add missing logging keys to docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,9 @@ services:
   file:
     image: semtech/mu-file-service:3.1.0
     restart: always
+    logging: *default-logging
+    labels:
+      - "logging=true"
     links:
       - database:database
     volumes:
@@ -155,10 +158,14 @@ services:
   codex-proxy:
     image: lblod/codex-reverse-proxy-service
     logging: *default-logging
+    labels:
+      - "logging=true"
     restart: always
   agendapoint-service:
     image: lblod/gn-agendapoint-service:1.0.3
     logging: *default-logging
+    labels:
+      - "logging=true"
     restart: always
   dashboard:
     image: lblod/frontend-dashboard:1.4.0
@@ -246,3 +253,6 @@ services:
     environment:
       BACKEND_HOST: database
     restart: always
+    logging: *default-logging
+    labels:
+      - "logging=true"


### PR DESCRIPTION
### Overview
Add missing logging keys to GN, following Niels recommendation, I also added the file service which he probably forgot, and updated controle-editor controle-identifier and mocklogin directly in prod as they were defined in the override

##### connected issues and PRs:
GN-5505


### Setup
None

### How to test/reproduce
Check that the services logging labels are there I guess 

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
