### PR TITLE
ci: add pipeline to validate resource models

### DIFF
--- a/.woodpecker/validate-resource-models.yml
+++ b/.woodpecker/validate-resource-models.yml
@@ -1,0 +1,11 @@
+steps:
+  validate-resource-models:
+    image: madnificent/cl-resources-plantuml-generator
+    commands:
+      - mkdir /config/output
+      - cp -R ./config/resources/* /app/configuration/
+      - cd /
+      - sbcl --disable-debugger --load /usr/src/startup.lisp
+when:
+  event:
+    - pull_request

--- a/.woodpecker/validate-resource-models.yml
+++ b/.woodpecker/validate-resource-models.yml
@@ -1,3 +1,9 @@
+clone:
+  git:
+    image: woodpeckerci/plugin-git
+    settings:
+      lfs: false
+
 steps:
   validate-resource-models:
     image: madnificent/cl-resources-plantuml-generator


### PR DESCRIPTION
### Overview
This PR adds a CI step which validates the resource models of this app through the `madnificent/cl-resources-plantuml-generator` service
