### PR TITLE
GN-5568: add support for generic user preferences

### DIFF
--- a/.changeset/nine-moles-itch.md
+++ b/.changeset/nine-moles-itch.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Add support for generic user preferences

--- a/.woodpecker/validate-resource-models.yml
+++ b/.woodpecker/validate-resource-models.yml
@@ -3,6 +3,7 @@ clone:
     image: woodpeckerci/plugin-git
     settings:
       lfs: false
+      remote: ${CI_REPO_CLONE_URL}
 
 steps:
   validate-resource-models:

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -136,7 +136,7 @@ defmodule Acl.UserGroups.Config do
                         "http://mu.semte.ch/vocabularies/ext/Installatievergadering",
                         "http://mu.semte.ch/vocabularies/ext/InstallatievergaderingSynchronizationStatus",
                         "http://data.lblod.info/vocabularies/gelinktnotuleren/AangepasteStemming",
-                        "http://mu.semte.ch/vocabularies/ext/UserPreferences",
+                        "http://mu.semte.ch/vocabularies/ext/UserPreference",
                       ] } } ] },
 
       %GroupSpec{
@@ -176,7 +176,7 @@ defmodule Acl.UserGroups.Config do
                         "http://mu.semte.ch/vocabularies/ext/Installatievergadering",
                         "http://mu.semte.ch/vocabularies/ext/InstallatievergaderingSynchronizationStatus",
                         "http://data.lblod.info/vocabularies/gelinktnotuleren/AangepasteStemming",
-                        "http://mu.semte.ch/vocabularies/ext/UserPreferences",
+                        "http://mu.semte.ch/vocabularies/ext/UserPreference",
                       ] } } ] },
 
       %GroupSpec{

--- a/config/migrations/20250410105333-introduce-user-preference-concept-scheme.sparql
+++ b/config/migrations/20250410105333-introduce-user-preference-concept-scheme.sparql
@@ -31,9 +31,9 @@ INSERT {
     ?uri a skos:Concept;
          mu:uuid ?uuid;
          skos:inScheme <http://lblod.data.gift/concept-schemes/f9bd0f31-8932-4a04-8c79-f92066c991f3>;
-         skos:notation 'meeting.sidebar.navigation.collapsed';
-         skos:prefLabel "Collapsed state of meeting navigation section";
-         skos:note "Controls whether or not the navigation section of the meeting sidebar is collapsed".
+         skos:notation 'meeting.sidebar.navigation.expanded';
+         skos:prefLabel "Expanded state of meeting navigation section";
+         skos:note "Controls whether or not the navigation section of the meeting sidebar is expanded".
   }
 }
 WHERE {

--- a/config/migrations/20250410105333-introduce-user-preference-concept-scheme.sparql
+++ b/config/migrations/20250410105333-introduce-user-preference-concept-scheme.sparql
@@ -1,0 +1,42 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?uri a skos:ConceptScheme;
+         mu:uuid ?uuid;
+         skos:prefLabel "User preference schema".
+  }
+}
+WHERE {
+  BIND("f9bd0f31-8932-4a04-8c79-f92066c991f3" AS ?uuid)
+  BIND(URI(CONCAT("http://lblod.data.gift/concept-schemes/", ?uuid)) as ?uri)
+};
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?uri a skos:Concept;
+         mu:uuid ?uuid;
+         skos:inScheme <http://lblod.data.gift/concept-schemes/f9bd0f31-8932-4a04-8c79-f92066c991f3>;
+         skos:notation 'favourite-templates';
+         skos:prefLabel "Favourite templates";
+         skos:note "List of favourite templates which are shown when creating a new editor document".
+  }
+}
+WHERE {
+  BIND("c9d00675-e6b8-4a83-b5e3-1631842f8e4a" AS ?uuid)
+  BIND(URI(CONCAT("http://lblod.data.gift/concepts/", ?uuid)) as ?uri)
+};
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?uri a skos:Concept;
+         mu:uuid ?uuid;
+         skos:inScheme <http://lblod.data.gift/concept-schemes/f9bd0f31-8932-4a04-8c79-f92066c991f3>;
+         skos:notation 'meeting.sidebar.navigation.collapsed';
+         skos:prefLabel "Collapsed state of meeting navigation section";
+         skos:note "Controls whether or not the navigation section of the meeting sidebar is collapsed".
+  }
+}
+WHERE {
+  BIND("a006e8d3-904b-45a9-a737-3b622076c7d2" AS ?uuid)
+  BIND(URI(CONCAT("http://lblod.data.gift/concepts/", ?uuid)) as ?uri)
+}

--- a/config/migrations/20250410105334-move-user-preferences-to-user-preference.sparql
+++ b/config/migrations/20250410105334-move-user-preferences-to-user-preference.sparql
@@ -1,0 +1,28 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH ?g {
+    ?userPreferences a ext:UserPreferences;
+                     ext:favouriteTemplates ?favouriteTemplates;
+                     ext:preferencesFor ?user.
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?userPreference a ext:UserPreference;
+                    # `favourite-templates` concept
+                    ext:type <http://lblod.data.gift/concepts/c9d00675-e6b8-4a83-b5e3-1631842f8e4a>;
+                    ext:value ?favouriteTemplates.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?userPreferences a ext:UserPreferences;
+                  	 ext:favouriteTemplates ?favouriteTemplates;
+                     ext:preferencesFor ?user.
+  }
+  BIND(STRUUID() as ?userPreferenceId)
+  BIND(URI(CONCAT("http://data.lblod.gift/user-preference/", ?userPreferenceId)) as ?userPreference)
+}

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -33,6 +33,7 @@
   :class (s-prefix "skos:Concept")
   :properties `((:label :string ,(s-prefix "skos:prefLabel"))
                 (:notation :string ,(s-prefix "skos:notation"))
+                (:note :string ,(s-prefix "skos:note"))
                 (:search-label :string ,(s-prefix "ext:searchLabel")))
   :has-many `((concept-scheme :via ,(s-prefix "skos:inScheme")
                               :as "concept-schemes")
@@ -123,19 +124,21 @@
   :has-many `((account :via ,(s-prefix "foaf:account")
                        :as "account")
               (bestuurseenheid :via ,(s-prefix "foaf:member")
-                              :as "bestuurseenheden"))
-  :has-one `((user-preferences :via ,(s-prefix "ext:preferencesFor")
-                            :inverse t
-                            :as "preferences"))
+                               :as "bestuurseenheden")
+              (user-preference :via ,(s-prefix "ext:preferenceFor")
+                               :inverse t
+                               :as "preferences"))
   :on-path "gebruikers"
 )
 
-(define-resource user-preferences ()
-  :class (s-prefix "ext:UserPreferences")
-  :resource-base (s-url "http://data.lblod.gift/user-preferences/")
-  :properties `((:favourite-templates :string ,(s-prefix "ext:favouriteTemplates")))
-  :has-one `((gebruiker :via ,(s-prefix "ext:preferencesFor")
-                            :as "gebruiker"))
+(define-resource user-preference ()
+  :class (s-prefix "ext:UserPreference")
+  :resource-base (s-url "http://data.lblod.gift/user-preference/")
+  :properties `((:value :string ,(s-prefix "ext:value")))
+  :has-one `((gebruiker :via ,(s-prefix "ext:preferenceFor")
+                            :as "gebruiker")
+             (concept :via ,(s-prefix "ext:type")
+                            :as "type"))
   :on-path "user-preferences"
 )
 


### PR DESCRIPTION
### Overview
This PR adds support for generic user preferences.
What does this PR include?:
- A new `user-preference` model, which replaces `user-preferences`
  * A `user-preference` is linked to a user, a user-preference type and contains a (string) value
- User preference types are represented by `skos` concepts.
  * Each user preference type has a `label`, a `note` (description) and a `notation` (unique string to identify the preference type/concept)
  * Two concepts have already been added
    - `favourite-templates`
    - `meeting.sidebar.navigation.collapsed`
- The user-preference concepts are linked to a user-preference concept-scheme

Values of user preferences are always stored as strings, it is up to the consuming application to parse/validate these string values.

TODOs:

- [ ] Release frontend + update this PR

##### connected issues and PRs:
https://github.com/lblod/frontend-gelinkt-notuleren/pull/845
[GN-5568](https://binnenland.atlassian.net/browse/GN-5568?atlOrigin=eyJpIjoiNTNiZDc3MjRhYTYxNGZjZmIwZDNjNDkyMjdlODllZWYiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the `virtuoso` and `migrations` services
- Ensure the migrations run as expected
- Test https://github.com/lblod/frontend-gelinkt-notuleren/pull/845

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
