### PR TITLE
GN-5628: add migration containing end dates of 2019-2024 administrative bodies

### DIFF
--- a/.changeset/six-cobras-look.md
+++ b/.changeset/six-cobras-look.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Addition of migrations which sets the end-dates of the administrative bodies of the 2019-2024 legislation

--- a/config/migrations/20250613115359-add-bestuursorgaan-end-dates.sparql
+++ b/config/migrations/20250613115359-add-bestuursorgaan-end-dates.sparql
@@ -1,0 +1,20 @@
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT {
+  GRAPH ?g {
+    ?bestuursorgaan mandaat:bindingEinde "2025-01-01T00:00:00Z"^^xsd:dateTime .
+  }
+}
+WHERE {
+ GRAPH ?g {
+  ?bestuursorgaan 
+    a besluit:Bestuursorgaan;
+    lmb:heeftBestuursperiode <http://data.lblod.info/id/concept/Bestuursperiode/a2b977a3-ce68-4e42-80a6-4397f66fc5ca>.
+  FILTER NOT EXISTS {
+    ?bestuursorgaan mandaat:bindingEinde ?einde.
+  }
+ }
+}


### PR DESCRIPTION
### Overview
Addition of migration which sets the end-dates of the administrative bodies of the 2019-2024 legislation


##### connected issues and PRs:
[GN-5628](https://binnenland.atlassian.net/browse/GN-5628?atlOrigin=eyJpIjoiMTRlOTJjYzJiMGNiNDY4YzgzNjY0NDNkNDQzMzI4NTMiLCJwIjoiaiJ9)
https://github.com/lblod/frontend-gelinkt-notuleren/pull/864

### How to test/reproduce
- Execute the migration
- Visit the frontend
- The administrative bodies of the previous legislation should no longer show up when creating a meeting

### Challenges/uncertainties
I still opted to specify the full date, as this is similar to what the other applications do. The predicate used to store these dates is also defined withing the `mandaat` namespace, so I don't know if we have a lot of liberty to change the predicate range datatype.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
