### PR TITLE
Remove property attribute from standard template decisions

### DIFF
--- a/.changeset/gorgeous-socks-poke.md
+++ b/.changeset/gorgeous-socks-poke.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Remove property attribute from decisions in standard templates to prevent it being interpreted as a backlink in RDFa aware documents

--- a/config/migrations/20250619131120-remove-template-generated-prop-minimaal-besluit.sparql
+++ b/config/migrations/20250619131120-remove-template-generated-prop-minimaal-besluit.sparql
@@ -1,0 +1,33 @@
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/b04fc03e-e8ff-496a-9343-1f07b4f55551> <http://mu.semte.ch/vocabularies/ext/templateContent> ?templateContent
+  }
+};
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/b04fc03e-e8ff-496a-9343-1f07b4f55551> <http://mu.semte.ch/vocabularies/ext/templateContent> 
+    """
+    <div
+      resource="http://data.lblod.info/id/besluiten/--ref-uuid4-a03ac0ee-b301-42ef-bcfd-1db56cbf7a0a"
+      typeof="besluit:Besluit ext:BesluitNieuweStijl"
+      data-label="Besluit"
+    >
+      <div style="display: none" data-rdfa-container="true">
+        <span
+          property="eli:language"
+          resource="http://publications.europa.eu/resource/authority/language/NLD"
+        />
+      </div>
+      <div data-content-container="true">
+        <div property="eli:title" datatype="xsd:string" data-label="Openbare titel besluit">
+          <h4><span class="mark-highlight-manual">Geef titel besluit op</span></h4>
+        </div>
+        <br />
+        <div property="eli:description" datatype="xsd:string" data-label="Korte openbare beschrijving">
+          <p><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
+        </div>
+      </div>
+    </div>
+    """.
+  }
+}

--- a/config/migrations/20250619131154-remove-template-generated-prop-nieuw-besluit.sparql
+++ b/config/migrations/20250619131154-remove-template-generated-prop-nieuw-besluit.sparql
@@ -1,0 +1,74 @@
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/6933312e-2bac-11e9-af69-3baeff70b1a8> <http://mu.semte.ch/vocabularies/ext/templateContent> ?templateContent
+  }
+};
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/6933312e-2bac-11e9-af69-3baeff70b1a8> <http://mu.semte.ch/vocabularies/ext/templateContent> 
+    """
+    <div
+      resource="http://data.lblod.info/id/besluiten/--ref-uuid4-c10209c0-dfba-46fb-80c7-1c6aedf656e9"
+      typeof="besluit:Besluit ext:BesluitNieuweStijl"
+      data-label="Besluit"
+    >
+      <div style="display: none" data-rdfa-container="true">
+        <span
+          property="eli:language"
+          resource="http://publications.europa.eu/resource/authority/language/NLD"
+        />
+      </div>
+      <div data-content-container="true">
+        <div
+          property="eli:title"
+          datatype="xsd:string"
+          data-label="Openbare titel besluit"
+        >
+          <h4><span class="mark-highlight-manual">Geef titel besluit op</span></h4>
+        </div>
+        <div
+          property="eli:description"
+          datatype="xsd:string"
+          data-label="Korte openbare beschrijving"
+        >
+          <p><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
+        </div>
+        <div property="besluit:motivering" lang="nl" data-label="Motivering">
+          <p><span class="mark-highlight-manual">geef bestuursorgaan op</span>,</p>
+          <br />
+          <h5>Bevoegdheid</h5>
+          <ul class="bullet-list">
+            <li><span class="mark-highlight-manual">Rechtsgrond die bepaalt dat dit orgaan bevoegd is.</span></li>
+          </ul>
+          <br />
+          <h5>Juridische context</h5>
+          <ul class="bullet-list">
+            <li><span class="mark-highlight-manual">Voeg juridische context in</span></li>
+          </ul>
+          <br />
+          <h5>Feitelijke context en argumentatie</h5>
+          <ul class="bullet-list">
+            <li><span class="mark-highlight-manual">Voeg context en argumentatie in</span></li>
+          </ul>
+        </div>
+        <br />
+        <br />
+        <h5>Beslissing</h5>
+        <div property="prov:value" datatype="xsd:string" data-label="Artikels">
+          <div
+            property="eli:has_part"
+            resource="http://data.lblod.info/artikels/--ref-uuid4-7a0552ff-4fb1-4e42-98d6-dd88faf60f0c"
+            typeof="besluit:Artikel"
+            data-say-is-only-article="true"
+          >
+            <div>Artikel <span property="eli:number" datatype="xsd:string">1</span></div>
+            <div property="prov:value" datatype="xsd:string">
+              <span class="mark-highlight-manual">Voer inhoud in</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """.
+  }
+}

--- a/config/migrations/20250619131207-remove-template-generated-prop-klassiek-besluit.sparql
+++ b/config/migrations/20250619131207-remove-template-generated-prop-klassiek-besluit.sparql
@@ -1,0 +1,73 @@
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/39c31a7e-2ba9-11e9-88cf-83ebfda837dc> <http://mu.semte.ch/vocabularies/ext/templateContent> ?templateContent
+  }
+};
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/39c31a7e-2ba9-11e9-88cf-83ebfda837dc> <http://mu.semte.ch/vocabularies/ext/templateContent> 
+    """
+    <div
+      resource="http://data.lblod.info/id/besluiten/--ref-uuid4-5ab24a9b-4760-4607-81c1-38dd53c13dff"
+      typeof="besluit:Besluit ext:BesluitKlassiekeStijl"
+      data-label="Besluit"
+    >
+      <div style="display: none" data-rdfa-container="true">
+        <span
+          property="eli:language"
+          resource="http://publications.europa.eu/resource/authority/language/NLD"
+        />
+      </div>
+      <div data-content-container="true">
+        <div
+          property="eli:title"
+          datatype="xsd:string"
+          data-label="Openbare titel besluit"
+        >
+          <h5><span class="mark-highlight-manual">Geef titel besluit op</span></h5>
+        </div>
+        <div
+          property="eli:description"
+          datatype="xsd:string"
+          data-label="Korte openbare beschrijving"
+        >
+          <p><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
+        </div>
+        <div property="besluit:motivering" lang="nl" data-label="Motivering">
+          <p><span class="mark-highlight-manual">geef bestuursorgaan op</span>,</p>
+          <br />
+          <div>
+            <ul class="bullet-list">
+              <li>Gelet op <span class="mark-highlight-manual">Voeg juridische grond in</span>;</li>
+            </ul>
+          </div>
+          <br />
+          <div>
+            <ul class="bullet-list">
+              <li>Overwegende dat <span class="mark-highlight-manual">Voeg motivering in</span>;</li>
+            </ul>
+          </div>
+        </div>
+        <br />
+        <br />
+        <p class="u-spacer--small">Beslist,</p>
+        <div property="prov:value" datatype="xsd:string" data-label="Artikels">
+          <div
+            property="eli:has_part"
+            resource="http://data.lblod.info/artikels/--ref-uuid4-69ba01d6-db79-4b36-8ed4-d824269724df"
+            typeof="besluit:Artikel"
+            data-say-is-only-article="true"
+          >
+            <div>
+              Artikel <span property="eli:number" datatype="xsd:string">1</span>
+            </div>
+            <div property="prov:value" datatype="xsd:string">
+              <span class="mark-highlight-manual">Voer inhoud in</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """.
+  }
+}

--- a/config/migrations/20250619131300-remove-template-generated-prop-reglement.sparql
+++ b/config/migrations/20250619131300-remove-template-generated-prop-reglement.sparql
@@ -1,0 +1,79 @@
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/2deed136-94c2-47ec-a542-8746cd020579> <http://mu.semte.ch/vocabularies/ext/templateContent> ?templateContent
+  }
+};
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.info/templates/2deed136-94c2-47ec-a542-8746cd020579> <http://mu.semte.ch/vocabularies/ext/templateContent> 
+    """
+    <div
+      resource="http://data.lblod.info/id/besluiten/--ref-uuid4-c10209c0-dfba-46fb-80c7-1c6aedf656e9"
+      typeof="besluit:Besluit https://data.vlaanderen.be/id/concept/BesluitType/67378dd0-5413-474b-8996-d992ef81637a ext:BesluitNieuweStijl"
+      data-label="Besluit"
+    >
+      <div style="display: none" data-rdfa-container="true">
+        <span
+          property="eli:language"
+          resource="http://publications.europa.eu/resource/authority/language/NLD"
+        />
+      </div>
+      <div data-content-container="true">
+        <div property="eli:title" datatype="xsd:string" data-label="Openbare titel besluit">
+          <h4><span class="mark-highlight-manual">Geef titel besluit op</span></h4>
+        </div>
+        <div property="eli:description" datatype="xsd:string" data-label="Korte openbare beschrijving">
+          <p><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
+        </div>
+        <br />
+        <div property="besluit:motivering" lang="nl" data-label="Motivering">
+          <p><span class="mark-highlight-manual">geef bestuursorgaan op</span>, </p>
+        <br> 
+        <h5>Bevoegdheid</h5> 
+        <ul class="bullet-list"> 
+          <li><span class="mark-highlight-manual">Rechtsgrond die bepaalt dat dit orgaan bevoegd is.</span></li> 
+        </ul> 
+        <br> 
+        <h5>Juridische context</h5>
+        <ul class="bullet-list"> 
+          <li><a class="annotation" property="eli:cites" typeof="eli:LegalExpression" href="https://codex.vlaanderen.be/doc/document/1009730">Nieuwe gemeentewet</a>&nbsp;(KB 24/06/1988)</li> 
+          <li>decreet <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1029017" property="eli:cites" typeof="eli:LegalExpression">over het lokaal bestuur</a> van 22/12/2017</li> 
+          <li>wet <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1009628" property="eli:cites" typeof="eli:LegalExpression">betreffende de politie over het wegverkeer (wegverkeerswet - Wet van 16 maart 1968)</a></li> 
+          <li>wegcode - Koninklijk Besluit <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1036242" property="eli:cites" typeof="eli:LegalExpression">van 1 december 1975 houdende algemeen reglement op de politie van het wegverkeer en van het gebruik van de openbare weg.</a></li> 
+          <li>code van de wegbeheerder - <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1035575" property="eli:cites" typeof="eli:LegalExpression">ministerieel besluit van 11 oktober 1976 houdende de minimumafmetingen en de bijzondere plaatsingsvoorwaarden van de verkeerstekens</a></li> 
+        </ul> 
+        <br> 
+        <em>specifiek voor aanvullende reglementen op het wegverkeer (= politieverordeningen m.b.t. het wegverkeer voor wat betreft permanente of periodieke verkeerssituaties)</em> 
+        <ul class="bullet-list"> 
+          <li>decreet <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1016816" property="eli:cites" typeof="eli:LegalExpression">betreffende de aanvullende reglementen op het wegverkeer en de plaatsing en bekostiging van de verkeerstekens </a>(16 mei 2008)</li> 
+          <li>Besluit van de Vlaamse Regering <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1017729" property="eli:cites" typeof="eli:LegalExpression">betreffende de aanvullende reglementen en de plaatsing en bekostiging van verkeerstekens</a>​ van 23 januari 2009</li> 
+          <li><a href="https://codex.vlaanderen.be/doc/document/1035938" property="eli:cites" typeof="eli:LegalExpression">Omzendbrief MOB/2009/01 van 3 april 2009 gemeentelijke aanvullende reglementen op de politie over het wegverkeer</a></li> 
+        </ul> 
+        <h5>Feitelijke context en argumentatie</h5> 
+        <ul class="bullet-list"> 
+          <li><span class="mark-highlight-manual">Voeg context en argumentatie in</span></li> 
+        </ul> 
+        </div>
+        <br />
+        <br />
+        <h5>Beslissing</h5>
+        <div property="prov:value" datatype="xsd:string" data-label="Artikels">
+          <div
+            property="eli:has_part"
+            resource="http://data.lblod.info/artikels/--ref-uuid4-68c56ef4-8843-4b7f-a72a-9d0038ff723f"
+            typeof="besluit:Artikel"
+            data-say-is-only-article="true"
+          >
+            <div>
+              Artikel <span property="eli:number" datatype="xsd:string">1</span>
+            </div>
+            <div property="prov:value" datatype="xsd:string">
+              <span class="mark-highlight-manual">Voer inhoud in</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """.
+  }
+}


### PR DESCRIPTION
### Overview

This was being picked up by the RDFa aware parsing and being interpreted as a backlink to example.org, instead of being left hanging and then being completed in the prepublishing process.

We should finish off the move of standard-template-plugin templates to RB instead of having them in two places...

##### connected issues and PRs:
Part of [binnenland.atlassian.net/browse/GN-5633](https://binnenland.atlassian.net/browse/GN-5633)
Along with https://github.com/lblod/notulen-prepublish-service/pull/127
and https://github.com/lblod/besluit-publicatie-publish-service/pull/15
Matches the changes in https://github.com/lblod/app-reglementaire-bijlage/pull/95

### Setup
Can be tested standalone or as part of a publish e2e test.

### How to test/reproduce
Just with GN:
- Enable rdfa editing to facilitate inspecting RDFa links
- Create a new agendapoint
- Use the insert sidebar buttons to insert one of the 'standard' templates
- See that the Besluit node does not have any backlinks (previously there was a backlink `prov:generated` that pointed to example.org

With e2e publish test:
- Follow the instructions in the other PR... (tbc)

### Challenges/uncertainties
Thought about moving away from bundled templates to RB ones...

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
