### PR TITLE
set up sparql wrapper

### DIFF
--- a/.changeset/sixty-actors-call.md
+++ b/.changeset/sixty-actors-call.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Put sparql endpoint behind auth wrapper

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -374,7 +374,7 @@ defmodule Dispatcher do
   end
 
   match "/raw-sparql" do
-    forward conn, [], "http://database:8890/sparql"
+    forward conn, [], "http://sparql-wrapper/sparql"
   end
 
   

--- a/config/sparql-wrapper/filter.js
+++ b/config/sparql-wrapper/filter.js
@@ -1,0 +1,20 @@
+import { query, sparqlEscapeUri } from 'mu';
+
+
+export async function isAuthorized(sessionUri) {
+  const checkSessionQuery = `
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+    SELECT DISTINCT ?session_group WHERE {
+      ${sparqlEscapeUri(sessionUri)} ext:sessionGroup/mu:uuid ?session_group;
+                     ext:sessionRole ?role.
+     FILTER(?role in (\"GelinktNotuleren-lezer\",\"GelinktNotuleren-schrijver\", \"GelinktNotuleren-publiceerder\",  \"GelinktNotuleren-ondertekenaar\"))
+     }
+  `;
+  const response = await query(checkSessionQuery, { sudo: true});
+  // We want exactly one result, only one session should exist at a certain time.
+  const exists = response.results?.bindings?.length === 1;
+  console.log(`${sessionUri} exists? ${exists}`);
+  return exists;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,7 +239,8 @@ services:
   sparql-cache:
     image: redpencil/varnish-post:1.0.0
     environment:
-      BACKEND_HOST: database
+      BACKEND_HOST: sparql-wrapper
+      BACKEND_PORT: 80
     restart: always
     logging: *default-logging
     labels:
@@ -267,3 +268,11 @@ services:
     environment:
       MOW_ENDPOINT: 'https://roadsigns.lblod.info/sparql'
       ALLOW_MU_AUTH_SUDO: true
+
+  sparql-wrapper:
+    image: lblod/sparql-authorization-wrapper-service:1.1.1
+    volumes:
+      - ./config/sparql-wrapper:/config
+    environment:
+      LOG_SPARQL_ALL: "false"
+      ALLOW_MU_AUTH_SUDO: "true"


### PR DESCRIPTION
### Overview
Wraps the sparql endpoint in a service to ensure only logged in users can access the endpoint

##### connected issues and PRs:
https://github.com/lblod/frontend-gelinkt-notuleren/pull/919

### Setup
Test with the frontend linked above

### How to test/reproduce
- Test with the frontend, ensure queries are still successful when logged in
- Verify endpoint is not accessible when not logged in
- 
### Challenges/uncertainties
Performance impact of the session check should be limited, but verify it's ok.


### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] no new deprecations
