### PR TITLE
Bump services to latest working versions

### DIFF
--- a/.changeset/small-guests-beg.md
+++ b/.changeset/small-guests-beg.md
@@ -1,0 +1,13 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Bump service dependencies
+
+identifier: https://github.com/mu-semtech/mu-identifier/releases/tag/v1.11.0
+dispatcher: https://github.com/mu-semtech/mu-dispatcher/releases/tag/v2.1.1
+virtuoso: https://github.com/redpencilio/docker-virtuoso/releases/tag/v1.3.1
+migrations: https://github.com/mu-semtech/mu-migrations-service/releases/tag/v0.9.0
+login: https://github.com/lblod/acmidm-login-service/releases/tag/v0.12.1.rc-2
+file: https://github.com/mu-semtech/file-service/releases/tag/v3.5.0
+report-generation: https://github.com/lblod/loket-report-generation-service/releases/tag/v0.8.6-beta-7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
     labels:
       - "logging=true"
   login:
-    image: lblod/acmidm-login-service:0.8.0
+    image: lblod/acmidm-login-service:0.12.1.rc-2
     environment:
       MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie-ti.vlaanderen.be/op"
       MU_APPLICATION_AUTH_CLIENT_ID: "68b1585d-0e13-4817-820e-c475207673ed"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     labels:
       - "logging=true"
   cache:
-    image: semtech/mu-cache:2.1.0
+    image: semtech/mu-cache:2.0.2
     links:
       - resource:backend
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,14 +211,14 @@ services:
     labels:
       - "logging=true"
   report-generation:
-    image: lblod/loket-report-generation-service:0.5.0
+    image: lblod/loket-report-generation-service:0.8.6-beta-7
     links:
       - database:database
     environment:
       DEFAULT_GRAPH: "http://mu.semte.ch/graphs/reports"
     volumes:
       - ./data/files:/share
-      - ./config/reports:/app/reports
+      - ./config/reports:/config
     restart: always
     logging: *default-logging
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,7 @@ services:
     volumes:
       - ./data/files/:/share/
   file:
-    image: semtech/mu-file-service:3.1.0
+    image: semtech/mu-file-service:3.5.0
     restart: always
     logging: *default-logging
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     labels:
       - "logging=true"
   virtuoso:
-    image: redpencil/virtuoso:1.2.2
+    image: redpencil/virtuoso:1.4.0
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     labels:
       - "logging=true"
   cache:
-    image: semtech/mu-cache:2.0.2
+    image: semtech/mu-cache:2.1.0
     links:
       - resource:backend
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,7 +192,7 @@ services:
       SESSION_COOKIE_SECURE: "on"
       SESSION_COOKIE_SAME_SITE: "None"
   dashboard-dispatcher:
-    image: semtech/mu-dispatcher:2.1.0-beta.1
+    image: semtech/mu-dispatcher:2.1.1
     volumes:
       - ./config/dashboard-dispatcher:/config
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     labels:
       - "logging=true"
   identifier:
-    image: semtech/mu-identifier:1.10.3
+    image: semtech/mu-identifier:1.11.0
     restart: always
     logging: *default-logging
     labels:
@@ -179,7 +179,7 @@ services:
     links:
       - identifier:backend
   dashboard-identifier:
-    image: semtech/mu-identifier:1.9.1
+    image: semtech/mu-identifier:1.11.0
     links:
       - dashboard-dispatcher:dispatcher
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     labels:
       - "logging=true"
   dispatcher:
-    image: semtech/mu-dispatcher:2.1.0-beta.1
+    image: semtech/mu-dispatcher:2.1.1
     volumes:
       - ./config/dispatcher:/config
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
     labels:
       - "logging=true"
   migrations:
-    image: semtech/mu-migrations-service:0.8.0
+    image: semtech/mu-migrations-service:0.9.0
     links:
       - virtuoso:database
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     labels:
       - "logging=true"
   virtuoso:
-    image: redpencil/virtuoso:1.4.0
+    image: redpencil/virtuoso:1.3.1
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

Went through all the services and bumped to the latest version, or the latest working version in the case of `virtuoso` and `mu-cache`

For the cache, see https://github.com/mu-semtech/mu-cache/issues/9

For virtuoso: 1.4.0 hangs on our report-generation queries. While they're not exactly mission-critical, it still indicates something changed. The queries themselves do look a bit quirky, so it might be that they were always a bit wrong, but that hasn't been investigated.

I just bumped to 1.3.1 as that version is widely used in production, 1.4.0 is still a bit fresh.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

Launch and try anything you can think of in the app

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness

- [x] changelog

