### PR TITLE
switch to vks stack

### DIFF
--- a/.changeset/selfish-melons-walk.md
+++ b/.changeset/selfish-melons-walk.md
@@ -1,0 +1,5 @@
+---
+"app-gelinkt-notuleren": minor
+---
+
+Start using vks-ldes stack for AR-designs

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -331,10 +331,10 @@ defmodule Dispatcher do
   # VKS
   ########
   get "/ar-designs/*path" do
-    forward conn, path, "http://vks-design-service/ar-designs/"
+    forward conn, path, "http://vendor-proxy/query-json/ar-designs/"
   end
   get "/measure-concepts/*path" do
-    forward conn, path, "http://vks-design-service/measure-concepts/"
+    forward conn, path, "http://vendor-proxy/query-json/measure-concepts/"
   end
 
   #########

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -64,3 +64,8 @@ services:
     restart: "no"
   ldes-client:
     restart: "no"
+  vendor-proxy:
+    restart: "no"
+    environment:
+      VENDOR_KEY: "test"
+      VENDOR_URI: "http://data.lblod.info/foaf/agent/id/caefd380-6f44-4907-950c-d68f3487a4a7"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -69,3 +69,4 @@ services:
     environment:
       VENDOR_KEY: "test"
       VENDOR_URI: "http://data.lblod.info/foaf/agent/id/caefd380-6f44-4907-950c-d68f3487a4a7"
+      QUERY_BASE_URL: "https://dev.vks-ldes.lblod.info"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -274,5 +274,4 @@ services:
   vendor-proxy:
      image: lblod/vendor-proxy-service:0.2.0
      environment:
-      QUERY_BASE_URL: "http://vks.localhost"
       AUTH_GROUP: "org-write"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,6 +275,4 @@ services:
      image: lblod/vendor-proxy-service:0.2.0
      environment:
       QUERY_BASE_URL: "http://vks.localhost"
-      VENDOR_KEY: "test"
-      VENDOR_URI: "http://data.lblod.info/foaf/agent/id/caefd380-6f44-4907-950c-d68f3487a4a7"
       AUTH_GROUP: "org-write"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,16 +260,6 @@ services:
     labels:
       - "logging=true"
 
-  vks-design-service:
-    restart: always
-    image: lblod/vks-design-service:0.5.0
-    environment:
-      MOW_ENDPOINT: 'https://roadsigns.lblod.info/sparql'
-      ALLOW_MU_AUTH_SUDO: true
-    logging: *default-logging
-    labels:
-      - "logging=true"
-
   sparql-wrapper:
     restart: always
     image: lblod/sparql-authorization-wrapper-service:1.1.1
@@ -281,3 +271,10 @@ services:
     logging: *default-logging
     labels:
       - "logging=true"
+  vendor-proxy:
+     image: lblod/vendor-proxy-service:0.2.0
+     environment:
+      QUERY_BASE_URL: "http://vks.localhost"
+      VENDOR_KEY: "test"
+      VENDOR_URI: "http://data.lblod.info/foaf/agent/id/caefd380-6f44-4907-950c-d68f3487a4a7"
+      AUTH_GROUP: "org-write"


### PR DESCRIPTION
### Overview
Use the new vks stack on GN

##### connected issues and PRs:
https://github.com/lblod/vendor-proxy-service/pull/5
https://github.com/lblod/app-vks-ldes/pull/3
https://github.com/lblod/app-vks-ldes/pull/2


### Setup
Setup the local build of the vendor proxy service and run the vks stack locally with the 2 PR linked.

### How to test/reproduce
Modify the vendor proxy service to point to your vks stack locally and then user the AR-design functionality, it should work as before

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
